### PR TITLE
Updated files for release 1.0.66

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+chmpx (1.0.66) unstable; urgency=low
+
+  * Fixed build warning about comparison of pointer with integer
+
+ -- Takeshi Nakatani <nakatani@yahoo-corp.jp>  Wed, 26 Dec 2018 17:30:12 +0900
+
 chmpx (1.0.65) unstable; urgency=low
 
   * Updated common build tool files

--- a/lib/chmcommon.h
+++ b/lib/chmcommon.h
@@ -65,9 +65,9 @@ template<typename T> inline bool CHMEMPTYSTR(const T& pstr)
 #define CHMPXSTRJOIN(first, second)			first ## second
 
 #if defined(__cplusplus)
-#define	CHM_OFFSET(baseaddr, offset, type)	(offset > 0 ? reinterpret_cast<type>(reinterpret_cast<off_t>(baseaddr) + offset) : reinterpret_cast<type>(baseaddr)) 	// convert pointer with offset
-#define	CHM_ABS(baseaddr, offset, type)		(offset > 0 ? reinterpret_cast<type>(reinterpret_cast<off_t>(baseaddr) + reinterpret_cast<off_t>(offset)) : 0) 			// To Absorute address
-#define	CHM_REL(baseaddr, address, type)	(address > 0 ? reinterpret_cast<type>(reinterpret_cast<off_t>(address) - reinterpret_cast<off_t>(baseaddr)) : 0)		// To Relative address
+#define	CHM_OFFSET(baseaddr, offset, type)	(offset > 0 ? reinterpret_cast<type>(reinterpret_cast<off_t>(baseaddr) + offset) : reinterpret_cast<type>(baseaddr)) 					// convert pointer with offset
+#define	CHM_ABS(baseaddr, offset, type)		(reinterpret_cast<off_t>(offset) > 0 ? reinterpret_cast<type>(reinterpret_cast<off_t>(baseaddr) + reinterpret_cast<off_t>(offset)) : 0) // To Absorute address
+#define	CHM_REL(baseaddr, address, type)	(address > 0 ? reinterpret_cast<type>(reinterpret_cast<off_t>(address) - reinterpret_cast<off_t>(baseaddr)) : 0)						// To Relative address
 #else	// __cplusplus
 #define	CHM_OFFSET(baseaddr, offset, type)	(offset > 0 ? (type)((off_t)baseaddr + offset) : (type)baseaddr) 	// convert pointer with offset
 #define	CHM_ABS(baseaddr, offset, type)		(offset > 0 ? (type)((off_t)baseaddr + (off_t)offset) : 0) 			// To Absorute address


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Changes from 1.0.65 to 1.0.66
#### Fixed build warning about comparison of pointer with integer
- Fixed comparison of pointer with integer warning in chmcommon.h.

