### PR TITLE
Added check using cppcheck

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,6 +24,43 @@ SUBDIRS=lib src tests docs buildutils
 ACLOCAL_AMFLAGS = -I m4
 EXTRA_DIST=RELEASE_VERSION
 
+CPPCHECK_CMD=	cppcheck
+CPPCHECK_OPT=	--quiet \
+				--error-exitcode=1 \
+				--inline-suppr \
+				-j 4 \
+				--std=c++03 \
+				--xml-version=2 \
+				--enable=warning,style,information,missingInclude
+CPPCHECK_DEF=	-D SO_REUSEPORT
+CPPCHECK_IGN=
+
+# [NOTE]
+# Building chmpx on Travis CI is running in several OS.
+# Depending on the OS(CentOS, ubuntu, debian, fedora), different
+# cppcheck versions are installed. Certain versions of cppcheck
+# are incompatible with the chmpx template source code and are
+# very poor performance on the VM or container(Travis CI).
+# On problematic versions, timeout error on Travis CI.
+# To avoid this we skip only specific versions of cppcheck on
+# travis. Even if we skip a specific version of the cppcheck,
+# it will be tested with a combination of other versions and OS.
+# When running Travis, the TRAVIS_TAG environment variable is
+# set, and this environment variable is used for judgment.
+# 
+# Currently, debian uses cppcheck 1.76, and CentOS6 uses 1.63,
+# there is a problem with this old version, skipping this.
+# If debian/etc will support 1.8x or later versions in the
+# future, this skipped process will be unnecessary.
+#
+CPPCHECK_NGVER=	-e 1\\.7 -e 1\\.6
+
+cppcheck:
+	@echo "$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_DEF) $(CPPCHECK_IGN) $(SUBDIRS)"
+	@((((env | grep TRAVIS_TAG >/dev/null 2>&1) && echo -n TRAVISENVFOUND || echo -n NOTFOUND) && $(CPPCHECK_CMD) --version 2>/dev/null) | grep TRAVISENVFOUND | grep $(CPPCHECK_NGVER) >/dev/null 2>&1) && \
+		echo " --> Skip, because this old $(CPPCHECK_CMD) version is very poor performance on VM(CI)" || \
+		$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_DEF) $(CPPCHECK_IGN) $(SUBDIRS)
+
 #
 # VIM modelines
 #

--- a/buildutils/travis_builder.sh
+++ b/buildutils/travis_builder.sh
@@ -321,10 +321,27 @@ else
 	#
 	# Using RHSCL because centos has older ruby
 	#
-	run_cmd yum install -y -qq centos-release-scl
-	run_cmd yum install -y -qq rh-ruby23 rh-ruby23-ruby-devel rh-ruby23-rubygem-rake
+	run_cmd ${INSTALLER_BIN} install -y -qq centos-release-scl
+	run_cmd ${INSTALLER_BIN} install -y -qq rh-ruby23 rh-ruby23-ruby-devel rh-ruby23-rubygem-rake
 	source /opt/rh/rh-ruby23/enable
 	run_cmd ${GEM_BIN} install rubocop package_cloud
+fi
+
+#
+# For cppcheck
+#
+if [ ${IS_CENTOS} -eq 1 ]; then
+	#
+	# For CentOS, it need to allow EPEL(with setting disable)
+	#
+	run_cmd ${INSTALLER_BIN} install -y -qq epel-release
+	run_cmd yum-config-manager --disable epel
+	run_cmd ${INSTALLER_BIN} --enablerepo=epel install -y -qq cppcheck
+else
+	#
+	# Fedora, Ubuntu...
+	#
+	run_cmd ${INSTALLER_BIN} install -y -qq cppcheck
 fi
 
 #
@@ -337,6 +354,7 @@ SRCTOP="/tmp/${TMPSRCTOP}"
 run_cmd cd ${SRCTOP}
 run_cmd ./autogen.sh
 run_cmd ./configure --prefix=/usr ${CONFIGUREOPT}
+run_cmd make cppcheck
 run_cmd make
 run_cmd make check
 

--- a/lib/chmcntrl.cc
+++ b/lib/chmcntrl.cc
@@ -988,7 +988,7 @@ bool ChmCntrl::GetAllReplicateChmHashs(chmhash_t hash, chmhashlist_t& basehashs,
 {
 	if(!IsInitialized()){
 		ERR_CHMPRN("This object is not initialized yet.");
-		return -1L;
+		return false;
 	}
 	return ImData.GetServerChmHashsByHashs(hash, basehashs, with_pending, without_down, without_suspend);
 }

--- a/lib/chmconf.cc
+++ b/lib/chmconf.cc
@@ -221,7 +221,7 @@ CHMConf::CHMConf(int eventqfd, ChmCntrl* pcntrl, const char* file, short ctlport
 
 CHMConf::~CHMConf()
 {
-	Clean();
+	CHMConf::Clean();
 }
 
 bool CHMConf::Clean(void)
@@ -326,6 +326,8 @@ bool CHMConf::UnsetEventQueue(void)
 		}
 		CHM_CLOSE(inotifyfd);
 	}
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress redundantAssignment
 	inotifyfd	= CHM_INVALID_HANDLE;
 	watchfd		= CHM_INVALID_HANDLE;
 
@@ -901,6 +903,8 @@ bool CHMIniConf::LoadConfigurationRaw(CFGRAW& chmcfgraw) const
 		}
 	}
 
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress stlSize
 	if(0 < tmpmap.size()){
 		if(INICFG_INSEC_GLOBAL == section){
 			merge_strmap(chmcfgraw.global, tmpmap);
@@ -3408,6 +3412,8 @@ bool CHMYamlBaseConf::LoadConfiguration(CHMCFGINFO& chmcfginfo) const
 		// open configuration file
 		if(NULL == (fp = fopen(cfgfile.c_str(), "r"))){
 			ERR_CHMPRN("Could not open configuration file(%s). errno = %d", cfgfile.c_str(), errno);
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress resourceLeak
 			return false;
 		}
 

--- a/lib/chmconfutil.cc
+++ b/lib/chmconfutil.cc
@@ -74,6 +74,8 @@ bool extract_conf_value(string& value)
 				result			+= *ptr;			// not comment
 			}else if('\\' == *ptr){
 				result			+= *ptr;			// not to escape
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress duplicateBranch
 			}else if(0 != isspace(*ptr)){
 				result			+= *ptr;
 			}else{
@@ -106,6 +108,8 @@ bool extract_conf_value(string& value)
 				}else{
 					is_escape_char	= true;
 				}
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress duplicateBranch
 			}else if(0 != isspace(*ptr)){
 				if(is_escape_char){
 					result			+= '\\';

--- a/lib/chmconfutil.h
+++ b/lib/chmconfutil.h
@@ -73,7 +73,7 @@ typedef struct chm_yaml_data_pair_type{
 	yaml_event_type_t	first;
 	yaml_event_type_t	second;
 
-	chm_yaml_data_pair_type(yaml_event_type_t first_type = YAML_NO_EVENT) : first(first_type), second(YAML_NO_EVENT) {}
+	explicit chm_yaml_data_pair_type(yaml_event_type_t first_type = YAML_NO_EVENT) : first(first_type), second(YAML_NO_EVENT) {}
 
 }CHM_YAML_DATAPAIR;
 

--- a/lib/chmdbg.cc
+++ b/lib/chmdbg.cc
@@ -179,6 +179,8 @@ bool CHMDbgControl::SetChmDbgCntlFile(const char* filepath)
 	FILE*	newfp;
 	if(NULL == (newfp = fopen(filepath, "a+"))){
 		ERR_CHMPRN("Could not open debug file(%s). errno = %d", filepath, errno);
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress resourceLeak
 		return false;
 	}
 	*pchm_dbg_fp = newfp;

--- a/lib/chmeventbase.cc
+++ b/lib/chmeventbase.cc
@@ -40,7 +40,7 @@ ChmEventBase::ChmEventBase(int eventqfd, ChmCntrl* pcntrl) : eqfd(eventqfd), pCh
 
 ChmEventBase::~ChmEventBase()
 {
-	Clean();
+	ChmEventBase::Clean();
 }
 
 bool ChmEventBase::Clean(void)

--- a/lib/chmeventshm.cc
+++ b/lib/chmeventshm.cc
@@ -78,6 +78,7 @@ bool ChmEventShm::CheckProcessRunning(void* common_param, chmthparam_t wp_param)
 		WAN_CHMPRN("Failed to get pid list.");
 		return true;	// finish.
 	}
+	// cppcheck-suppress stlSize
 	if(0 == pidlist.size()){
 		// why?(nothing to do)
 		return true;
@@ -92,6 +93,7 @@ bool ChmEventShm::CheckProcessRunning(void* common_param, chmthparam_t wp_param)
 				down_pids.push_back(*iter);
 			}
 		}
+		// cppcheck-suppress stlSize
 		if(0 != down_pids.size()){
 			break;
 		}
@@ -177,7 +179,7 @@ ChmEventShm::~ChmEventShm()
 	if(!checkthread.ExitAllThreads()){
 		ERR_CHMPRN("Failed to exit thread for checking.");
 	}
-	Clean();
+	ChmEventShm::Clean();
 }
 
 bool ChmEventShm::Clean(void)
@@ -267,6 +269,8 @@ bool ChmEventShm::UnsetEventQueue(void)
 		}
 		CHM_CLOSE(inotifyfd);
 	}
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress redundantAssignment
 	inotifyfd	= CHM_INVALID_HANDLE;
 	watchfd		= CHM_INVALID_HANDLE;
 

--- a/lib/chmimdata.cc
+++ b/lib/chmimdata.cc
@@ -591,8 +591,6 @@ bool ChmIMData::InitializeShmEx(const CHMCFGINFO* pchmcfg, const CHMNODE_CFGINFO
 
 	// initialize data in shm
 	PCHMSHM	pChmBase = reinterpret_cast<PCHMSHM>(shmbase);
-	PCHMPX*	rel_pchmpxarr_base;
-	PCHMPX*	rel_pchmpxarr_pend;
 	{
 		PCHMPXLIST		rel_chmpxarea			= reinterpret_cast<PCHMPXLIST>(		sizeof(CHMSHM));
 		PCHMPX*			rel_pchmpxarrarea		= reinterpret_cast<PCHMPX*>(		sizeof(CHMSHM) +
@@ -615,8 +613,8 @@ bool ChmIMData::InitializeShmEx(const CHMCFGINFO* pchmcfg, const CHMNODE_CFGINFO
 																					sizeof(MQMSGHEADLIST) * (pchmcfg->max_server_mq_cnt + pchmcfg->max_client_mq_cnt) +
 																					sizeof(CLTPROCLIST) * MAX_CLTPROCLIST_COUNT(pchmcfg->max_client_mq_cnt, pchmcfg->mqcnt_per_attach) +
 																					sizeof(CHMLOGRAW) * pchmcfg->max_histlog_count);
-		rel_pchmpxarr_base						= rel_pchmpxarrarea;
-		rel_pchmpxarr_pend						= CHM_OFFSET(rel_pchmpxarrarea, static_cast<off_t>(sizeof(PCHMPX) * pchmcfg->max_chmpx_count), PCHMPX*);
+		PCHMPX*			rel_pchmpxarr_base		= rel_pchmpxarrarea;
+		PCHMPX*			rel_pchmpxarr_pend		= CHM_OFFSET(rel_pchmpxarrarea, static_cast<off_t>(sizeof(PCHMPX) * pchmcfg->max_chmpx_count), PCHMPX*);
 
 		// initializing each area
 		{
@@ -1767,8 +1765,8 @@ long ChmIMData::GetServerChmpxIdByBaseHash(chmhash_t basehash, chmpxidlist_t& ch
 	tmpchminfo.GetServerChmpxIdByHashs(another_basehash, another_chmpxids, false, true, true);
 
 	// merge two list to result list.
-	bool	found;
 	for(chmpxidlist_t::const_iterator iter1 = another_chmpxids.begin(); iter1 != another_chmpxids.end(); ++iter1){
+		bool	found;
 		found = false;
 		for(chmpxidlist_t::const_iterator iter2 = chmpxids.begin(); iter2 != chmpxids.end(); ++iter2){
 			if((*iter1) == (*iter2)){

--- a/lib/chmimdata.h
+++ b/lib/chmimdata.h
@@ -115,7 +115,7 @@ class ChmIMData
 		static void FreeDupSelfChmpxInfo(PCHMPX ptr);								// for free memory allocated by DupSelfChmpxInfo()
 		static bool IsSafeCHMINFO(const PCHMINFO pchminfo);
 
-		ChmIMData(bool is_chmpx_proc = true);
+		explicit ChmIMData(bool is_chmpx_proc = true);
 		virtual ~ChmIMData();
 
 		bool Close(void);
@@ -216,6 +216,7 @@ class ChmIMData
 		bool GetServerBase(chmpxid_t chmpxid, CHMPXSSL& ssl) const;
 		bool GetServerSocks(chmpxid_t chmpxid, socklist_t& socklist, int& ctlsock) const;
 		bool GetServerSock(chmpxid_t chmpxid, socklist_t& socklist) const { int tmp; return GetServerSocks(chmpxid, socklist, tmp); }
+		// cppcheck-suppress stlSize
 		bool IsConnectServer(chmpxid_t chmpxid) const { socklist_t tmpsocklist; return (GetServerSock(chmpxid, tmpsocklist) && 0 < tmpsocklist.size()); }
 		bool GetServerCtlSock(chmpxid_t chmpxid, int& ctlsock) const { socklist_t tmplist; return GetServerSocks(chmpxid, tmplist, ctlsock); }
 		bool GetServerHash(chmpxid_t chmpxid, chmhash_t& base, chmhash_t& pending) const;
@@ -238,6 +239,7 @@ class ChmIMData
 		long GetSlaveChmpxIds(chmpxidlist_t& list) const;
 		bool GetSlaveBase(chmpxid_t chmpxid, std::string& name, short& ctlport) const;
 		bool GetSlaveSock(chmpxid_t chmpxid, socklist_t& socklist) const;
+		// cppcheck-suppress stlSize
 		bool IsConnectSlave(chmpxid_t chmpxid) const { socklist_t tmplist; return (GetSlaveSock(chmpxid, tmplist) && 0 < tmplist.size()); }
 		chmpxsts_t GetSlaveStatus(chmpxid_t chmpxid) const;
 

--- a/lib/chmlockmap.tcc
+++ b/lib/chmlockmap.tcc
@@ -52,16 +52,17 @@ class chm_lock_map
 
 	protected:
 		// do not use this
+		// cppcheck-suppress uninitMemberVar
 		chm_lock_map(void) : lockval(FLCK_NOSHARED_MUTEX_VAL_UNLOCKED), pbasefunc(NULL), pbaseparam(NULL) {}
 
 	public:
-		chm_lock_map(val_type initval, chm_lock_map_erase_cb pfunc = NULL, void* pparam = NULL) : lockval(FLCK_NOSHARED_MUTEX_VAL_UNLOCKED), pbasefunc(pfunc), pbaseparam(pparam), emptyval(initval) {}
+		chm_lock_map(const val_type& initval, chm_lock_map_erase_cb pfunc = NULL, void* pparam = NULL) : lockval(FLCK_NOSHARED_MUTEX_VAL_UNLOCKED), pbasefunc(pfunc), pbaseparam(pparam), emptyval(initval) {}
 		virtual ~chm_lock_map(void) { clear(); }
 
 		inline size_t count(void);
 		inline val_type operator[](const key_type& key);
 		inline val_type get(const key_type& key);
-		inline bool set(const key_type& key, val_type val, bool allow_ow = false);
+		inline bool set(const key_type& key, const val_type& val, bool allow_ow = false);
 		inline bool find(const key_type& key);
 		inline void get_keys(st_key_list& list);
 		inline bool erase(const key_type& key);
@@ -123,7 +124,7 @@ inline val_type chm_lock_map<key_type, val_type>::get(const key_type& key)
 }
 
 template<typename key_type, typename val_type>
-inline bool chm_lock_map<key_type, val_type>::set(const key_type& key, val_type val, bool allow_ow)
+inline bool chm_lock_map<key_type, val_type>::set(const key_type& key, const val_type& val, bool allow_ow)
 {
 	while(!fullock::flck_trylock_noshared_mutex(&lockval));
 

--- a/lib/chmregex.cc
+++ b/lib/chmregex.cc
@@ -154,6 +154,7 @@ static bool expand_simple_regex(const string& simple_regex, strlst_t& expand_lst
 	strlst_t	simple_regex_lst;
 	string		one_simple_regex;
 
+	// cppcheck-suppress stlSize
 	for(simple_regex_lst.push_back(trim(simple_regex)); 0 < simple_regex_lst.size(); ){
 		one_simple_regex = simple_regex_lst.front();
 		simple_regex_lst.pop_front();
@@ -237,6 +238,7 @@ bool ExpandSimpleRegxHostname(const char* hostname, strlst_t& expand_lst, bool i
 	string	strhost = hostname;
 
 	expand_lst.clear();
+	// cppcheck-suppress stlSize
 	if(!expand_simple_regex(strhost, expand_lst) || 0 == expand_lst.size()){
 		ERR_CHMPRN("Failed to expand simple regex.");
 		return false;

--- a/lib/chmssgnutls.cc
+++ b/lib/chmssgnutls.cc
@@ -64,7 +64,7 @@ typedef struct chm_gnutls_ss_context{
 		strServerCert(CHMEMPTYSTR(pServerCert) ? "" : pServerCert), strServerPKey(CHMEMPTYSTR(pServerPKey) ? "" : pServerPKey), strSlaveCert(CHMEMPTYSTR(pSlaveCert) ? "" : pSlaveCert), strSlavePKey(CHMEMPTYSTR(pSlavePKey) ? "" : pSlavePKey)
 	{
 	}
-	chm_gnutls_ss_context(const struct chm_gnutls_ss_context* other) :
+	explicit chm_gnutls_ss_context(const struct chm_gnutls_ss_context* other) :
 		strServerCert(other ? other->strServerCert : ""), strServerPKey(other ? other->strServerPKey : ""), strSlaveCert(other ? other->strSlaveCert : ""), strSlavePKey(other ? other->strSlavePKey : "")
 	{
 	}
@@ -103,6 +103,9 @@ typedef struct chm_gnutls_ss_context{
 // variables but it is not used now. If you do not use default, you can set
 // gnutls_priority_t value.
 //
+// cppcheck-suppress unmatchedSuppression
+// cppcheck-suppress noOperatorEq
+// cppcheck-suppress noCopyConstructor
 typedef struct chm_gnutls_session{
 	bool								is_server;
 	ChmSSCtx							SSCtx;
@@ -113,6 +116,9 @@ typedef struct chm_gnutls_session{
 	chm_gnutls_session(bool is_svr = false, ChmSSCtx ctx = NULL, gnutls_certificate_credentials_t cert = NULL, gnutls_session_t ses = NULL, gnutls_priority_t pricache = NULL) :
 		is_server(is_svr), SSCtx(NULL), cert_cred(cert), session(ses), priority_cache(pricache)
 	{
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress noOperatorEq
+		// cppcheck-suppress noCopyConstructor
 		SSCtx = new ChmSSCtxEnt(ctx);
 	}
 
@@ -431,6 +437,9 @@ bool ChmSecureSock::CheckResultSSL(int sock, ChmSSSession sslsession, long actio
 	ChmSSSessionEnt*	ssl = reinterpret_cast<ChmSSSessionEnt*>(sslsession);
 
 	if(CHMEVENTSOCK_RETRY_DEFAULT == retrycnt){
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress uselessAssignmentPtrArg
+		// cppcheck-suppress uselessAssignmentArg
 		retrycnt = ChmEventSock::DEFAULT_RETRYCNT;
 		waittime = ChmEventSock::DEFAULT_WAIT_SOCKET;
 	}

--- a/lib/chmssnss.cc
+++ b/lib/chmssnss.cc
@@ -105,7 +105,7 @@ typedef struct chm_nss_ss_context{
 		strServerKey(CHMEMPTYSTR(pServer) ? "" : pServer), CERT_OBJ_server(cert_server), PKEY_OBJ_server(pkey_server), strSlaveKey(CHMEMPTYSTR(pSlave) ? "" : pSlave), CERT_OBJ_slave(cert_slave), PKEY_OBJ_slave(pkey_slave)
 	{
 	}
-	chm_nss_ss_context(const struct chm_nss_ss_context* other) :
+	explicit chm_nss_ss_context(const struct chm_nss_ss_context* other) :
 		strServerKey(other ? other->strServerKey : ""), CERT_OBJ_server(other ? other->CERT_OBJ_server : NULL), PKEY_OBJ_server(other ? other->PKEY_OBJ_server : NULL), strSlaveKey(other ? other->strSlaveKey : ""), CERT_OBJ_slave(other ? other->CERT_OBJ_slave : NULL), PKEY_OBJ_slave(other ? other->PKEY_OBJ_slave : NULL)
 	{
 	}
@@ -234,6 +234,8 @@ inline void move_pk11objlist(chmpk11list_t& srclist, chmpk11list_t& destlist)
 // [NOTE]
 // ChmSSSession is a pointer type casted void* to ChmSSSessionEnt structure.
 //
+// cppcheck-suppress unmatchedSuppression
+// cppcheck-suppress noCopyConstructor
 typedef struct chm_nss_session{
 	ChmSSCtx		SSCtx;
 	PRFileDesc*		SSSession;
@@ -241,6 +243,9 @@ typedef struct chm_nss_session{
 
 	chm_nss_session(ChmSSCtx ctx = NULL, PRFileDesc* session = NULL, chmpk11list_t* ppk11objs = NULL) : SSCtx(NULL), SSSession(session)
 	{
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress noOperatorEq
+		// cppcheck-suppress noCopyConstructor
 		SSCtx = new ChmSSCtxEnt(ctx);
 		if(ppk11objs){
 			set(*ppk11objs);
@@ -733,8 +738,7 @@ bool ChmSecureSock::LoadCACerts(chmpk11list_t& pk11objlist)
 		}
 	}
 	if(!ChmSecureSock::GetCAPath().empty()){
-		PRDirEntry*	entry;
-		PRDir*		dir;
+		PRDir*	dir;
 		if(NULL == (dir = PR_OpenDir(ChmSecureSock::GetCAPath().c_str()))){
 			WAN_CHMPRN("Could not open CA path(%s) directory, but continue...", ChmSecureSock::GetCAPath().c_str());
 		}else{
@@ -746,6 +750,7 @@ bool ChmSecureSock::LoadCACerts(chmpk11list_t& pk11objlist)
 			//
 			// AND WE NEED TO CHECK FILE EXTENSION OR FORMAT BEFORE CALLING PK11 FUNCTION.
 			//
+			PRDirEntry*	entry;
 			while(NULL != (entry = PR_ReadDir(dir, PR_SKIP_BOTH))){
 				if(0 == strcmp(entry->name, ".") || 0 == strcmp(entry->name, "..")){
 					continue;
@@ -1053,6 +1058,9 @@ bool ChmSecureSock::CheckResultSSL(int sock, ChmSSSession sslsession, long actio
 	//ChmSSSessionEnt*	session = reinterpret_cast<ChmSSSessionEnt*>(sslsession);		// not used
 
 	if(CHMEVENTSOCK_RETRY_DEFAULT == retrycnt){
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress uselessAssignmentPtrArg
+		// cppcheck-suppress uselessAssignmentArg
 		retrycnt = ChmEventSock::DEFAULT_RETRYCNT;
 		waittime = ChmEventSock::DEFAULT_WAIT_SOCKET;
 	}
@@ -1835,6 +1843,8 @@ void ChmSecureSock::FreeSSLSessionEx(ChmSSSession sslsession)
 //------------------------------------------------------
 // Methods
 //------------------------------------------------------
+// cppcheck-suppress unmatchedSuppression
+// cppcheck-suppress uninitMemberVar
 ChmSecureSock::ChmSecureSock(const char* CApath, const char* CAfile, bool is_verify_peer) : nss_ctx(NULL)
 {
 	if(!ChmSecureSock::InitLibrary(&nss_ctx, CApath, CAfile, is_verify_peer)){

--- a/lib/chmssopenssl.cc
+++ b/lib/chmssopenssl.cc
@@ -323,8 +323,8 @@ bool ChmSecureSock::CheckResultSSL(int sock, ChmSSSession sslsession, long actio
 	is_close = false;
 
 	bool	result = true;
-	int		werr;
 	if(action_result <= 0){
+		int	werr;
 		int	ssl_result = SSL_get_error(ssl, action_result);
 		switch(ssl_result){
 			case	SSL_ERROR_NONE:
@@ -583,10 +583,11 @@ ChmSSSession ChmSecureSock::HandshakeSSL(ChmSSCtx ctx, int sock, bool is_accept,
 	SSL_set_fd(ssl, sock);
 
 	// accept/connect
-	bool	is_retry;
 	bool	is_close = false;	// Not used this value.
 	long	action_result;
 	for(int tmp_retrycnt = con_retrycnt; 0 < tmp_retrycnt; --tmp_retrycnt){
+		bool	is_retry;
+
 		// accept
 		if(is_accept){
 			action_result = SSL_accept(ssl);
@@ -637,10 +638,11 @@ bool ChmSecureSock::ShutdownSSL(int sock, ChmSSSession sslsession, int con_retry
 		con_waittime = ChmEventSock::DEFAULT_WAIT_CONNECT;
 	}
 
-	bool	is_retry;
-	long	action_result;
 	bool	is_close = false;		// Not used this value.
 	for(int tmp_retrycnt = con_retrycnt; 0 < tmp_retrycnt; --tmp_retrycnt){
+		bool	is_retry;
+		long	action_result;
+
 		// accept
 		action_result	= SSL_shutdown(ssl);
 		is_retry		= true;

--- a/lib/chmstructure.tcc
+++ b/lib/chmstructure.tcc
@@ -1264,8 +1264,10 @@ int chmpx_lap<T>::GetSock(int type)
 		if(basic_type::pAbsPtr->socklist){
 			chmsocklistlap	tmpsocklist(basic_type::pAbsPtr->socklist, basic_type::pShmBase, false);	// From Relative
 			socklist_t		sockarr;
+			// cppcheck-suppress stlSize
 			if(tmpsocklist.GetAllSocks(sockarr) && 0 < sockarr.size()){
 				// return first sock.
+				// cppcheck-suppress stlSize
 				rtsock = sockarr.front();
 			}
 		}
@@ -2044,7 +2046,7 @@ bool chmpxlist_lap<T>::ToNextUpServicing(bool is_cycle, bool is_allow_same_serve
 				basic_type::pAbsPtr = startpos;		// restore
 				if(is_allow_same_server){
 					curchmpx.Reset(&basic_type::pAbsPtr->chmpx, abs_base_arr, abs_pend_arr, abs_sock_free_cnt, abs_sock_frees, basic_type::pShmBase);
-					chmpxsts_t	status = curchmpx.GetStatus();
+					status = curchmpx.GetStatus();
 					if(IS_CHMPXSTS_SERVICING(status) && (!without_suspend || IS_CHMPXSTS_NOSUP(status))){
 						return true;
 					}
@@ -2238,15 +2240,16 @@ bool chmpxlist_lap<T>::UpdateHash(int type, bool is_to_first)
 	}
 
 	st_ptr_type cur;
-	chmpxlap	curchmpx;
-	chmpxsts_t	status;
-	chmhash_t	base;
 	chmhash_t	newbase;
-	chmhash_t	pending;
 	chmhash_t	newpending;
 
 	ToFirst();
 	for(newbase = 0L, newpending = 0L, cur = basic_type::pAbsPtr; cur; cur = CHM_ABS(basic_type::pShmBase, cur->next, st_ptr_type)){
+		chmpxlap	curchmpx;
+		chmpxsts_t	status;
+		chmhash_t	base;
+		chmhash_t	pending;
+
 		curchmpx.Reset(&cur->chmpx, abs_base_arr, abs_pend_arr, abs_sock_free_cnt, abs_sock_frees, basic_type::pShmBase);
 
 		status	= curchmpx.GetStatus();
@@ -2688,8 +2691,9 @@ chmpxid_t chmpxlist_lap<T>::GetRandomChmpxId(bool is_up_servers)
 	long		pos = static_cast<long>(rand()) % basecnt;		// random position.
 
 	chmpxlap	curchmpx;
-	chmpxsts_t	status;
 	for(; 0 < pos && basic_type::pAbsPtr->next; basic_type::pAbsPtr = CHM_ABS(basic_type::pShmBase, basic_type::pAbsPtr->next, st_ptr_type)){
+		chmpxsts_t	status;
+
 		curchmpx.Reset(&basic_type::pAbsPtr->chmpx, abs_base_arr, abs_pend_arr, abs_sock_free_cnt, abs_sock_frees, basic_type::pShmBase);
 		status	= curchmpx.GetStatus();
 		if(IS_CHMPXSTS_BASEHASH(status) && (!is_up_servers || IS_CHMPXSTS_UP(status))){
@@ -4162,6 +4166,7 @@ bool chmlog_lap<T>::Get(PCHMLOGRAW plograwarr, long& arrsize, logtype_t dirmask,
 	// set start pos
 	bool	is_circled;
 	long	cur_pos;
+	// cppcheck-suppress nullPointer
 	if(CHMLOG_TYPE_NOTASSIGNED == abs_lograw[basic_type::pAbsPtr->max_log_count - 1L].log_type){
 		is_circled	= true;
 		cur_pos		= 0L;
@@ -4303,9 +4308,7 @@ bool cltproclist_lap<T>::Dump(std::stringstream& sstream, const char* spacer) co
 		return false;
 	}
 	std::string	tmpspacer1 = spacer ? spacer : "";
-	std::string	tmpspacer2;
 	tmpspacer1 += "  ";
-	tmpspacer2 += tmpspacer1 + "  ";
 
 	// To first
 	st_ptr_type	cur;
@@ -6012,6 +6015,7 @@ bool chmpxman_lap<T>::GetServerChmpxIdAndBaseHashByHashs(chmhash_t hash, chmpxid
 	if(CHM_INVALID_CHMPXID != last_chmpxid){
 		basic_type::pAbsPtr->last_chmpxid = last_chmpxid;						// for random
 	}
+	// cppcheck-suppress stlSize
 	return (0 != chmpxids.size());
 }
 
@@ -6040,7 +6044,7 @@ bool chmpxman_lap<T>::GetServerChmpxIdByHashs(chmhash_t hash, chmpxidlist_t& chm
 }
 
 template<typename T>
-long chmpxman_lap<T>::GetServerChmpxIds(chmpxidlist_t& list, bool with_pending, bool without_suspend, bool without_down) const
+long chmpxman_lap<T>::GetServerChmpxIds(chmpxidlist_t& list, bool with_pending, bool without_down, bool without_suspend) const
 {
 	if(!basic_type::pAbsPtr || !basic_type::pShmBase){
 		ERR_CHMPRN("PCHMPXMAN does not set.");
@@ -6050,7 +6054,7 @@ long chmpxman_lap<T>::GetServerChmpxIds(chmpxidlist_t& list, bool with_pending, 
 		return 0L;
 	}
 	chmpxlistlap	svrchmpxlist(basic_type::pAbsPtr->chmpx_servers, basic_type::pAbsPtr->chmpxid_map, AbsBaseArr(), AbsPendArr(), AbsSockFreeCnt(), AbsSockFrees(), basic_type::pShmBase, false);	// From rel
-	return svrchmpxlist.GetChmpxIds(list, with_pending, without_suspend, without_down);
+	return svrchmpxlist.GetChmpxIds(list, with_pending, without_down, without_suspend);
 }
 
 template<typename T>
@@ -7547,8 +7551,8 @@ msgid_t chminfo_lap<T>::AssignMsg(bool is_chmpx, bool is_activated)
 	}
 
 	// freed list
-	mqmsgheadlistlap	freed_msgs(basic_type::pAbsPtr->free_msgs, basic_type::pShmBase, false);		// From rel
-	PMQMSGHEADLIST		new_msghlst_ptr = freed_msgs.PopFront();										// Get abs
+	mqmsgheadlistlap	freed_msgs1(basic_type::pAbsPtr->free_msgs, basic_type::pShmBase, false);		// From rel
+	PMQMSGHEADLIST		new_msghlst_ptr = freed_msgs1.PopFront();										// Get abs
 	if(!new_msghlst_ptr){
 		ERR_CHMPRN("Could not get new msgheadlist.");
 		return CHM_INVALID_MSGID;
@@ -7556,7 +7560,7 @@ msgid_t chminfo_lap<T>::AssignMsg(bool is_chmpx, bool is_activated)
 	// Re-set freed list
 	//
 	basic_type::pAbsPtr->free_msg_count--;
-	basic_type::pAbsPtr->free_msgs = freed_msgs.GetFirstPtr(false);
+	basic_type::pAbsPtr->free_msgs = freed_msgs1.GetFirstPtr(false);
 
 	// Initialize new msghead list
 	mqmsgheadlistlap	new_msghlist(new_msghlst_ptr, basic_type::pShmBase);							// From abs
@@ -7574,12 +7578,12 @@ msgid_t chminfo_lap<T>::AssignMsg(bool is_chmpx, bool is_activated)
 
 		// For recovering, add freed list
 		new_mqmsghead.NotAccountMqFlag();
-		mqmsgheadlistlap	freed_msgs(basic_type::pAbsPtr->free_msgs, basic_type::pShmBase, false);	// From rel(allow NULL)
-		if(!freed_msgs.Push(new_msghlst_ptr, true)){
+		mqmsgheadlistlap	freed_msgs2(basic_type::pAbsPtr->free_msgs, basic_type::pShmBase, false);	// From rel(allow NULL)
+		if(!freed_msgs2.Push(new_msghlst_ptr, true)){
 			ERR_CHMPRN("Failed to add freed PMQMSGHEADLIST %p.", new_msghlst_ptr);
 		}else{
 			basic_type::pAbsPtr->free_msg_count++;
-			basic_type::pAbsPtr->free_msgs = freed_msgs.GetFirstPtr(false);
+			basic_type::pAbsPtr->free_msgs = freed_msgs2.GetFirstPtr(false);
 		}
 		return CHM_INVALID_MSGID;
 	}
@@ -7591,12 +7595,12 @@ msgid_t chminfo_lap<T>::AssignMsg(bool is_chmpx, bool is_activated)
 
 		// For recovering, add freed list
 		new_mqmsghead.NotAccountMqFlag();
-		mqmsgheadlistlap	freed_msgs(basic_type::pAbsPtr->free_msgs, basic_type::pShmBase, false);	// From rel(allow NULL)
-		if(!freed_msgs.Push(new_msghlst_ptr, true)){
+		mqmsgheadlistlap	freed_msgs3(basic_type::pAbsPtr->free_msgs, basic_type::pShmBase, false);	// From rel(allow NULL)
+		if(!freed_msgs3.Push(new_msghlst_ptr, true)){
 			ERR_CHMPRN("Failed to add freed PMQMSGHEADLIST %p.", new_msghlst_ptr);
 		}else{
 			basic_type::pAbsPtr->free_msg_count++;
-			basic_type::pAbsPtr->free_msgs	= freed_msgs.GetFirstPtr(false);
+			basic_type::pAbsPtr->free_msgs	= freed_msgs3.GetFirstPtr(false);
 		}
 		return CHM_INVALID_MSGID;
 	}

--- a/lib/chmthread.cc
+++ b/lib/chmthread.cc
@@ -368,9 +368,10 @@ int ChmThread::ExitThreads(int thread_cnt, bool is_wait)
 		return 0;
 	}
 
-	PCHMTHWP_PARAM	exit_pthparam;
-	int				exited_cnt;
+	int	exited_cnt;
 	for(exited_cnt = 0; exited_cnt < thread_cnt; ){
+		PCHMTHWP_PARAM	exit_pthparam;
+
 		fullock::flck_lock_noshared_mutex(&list_lockval);		// LOCK
 
 		// search sleep thread.
@@ -471,6 +472,7 @@ bool ChmThread::WaitExitThread(PCHMTHWP_PARAM thread_param)
 		thread_param->common_param	= NULL;
 		thread_param->wp_param		= 0;
 	}
+	// cppcheck-suppress uselessAssignmentPtrArg
 	CHM_Delete(thread_param);
 
 	return true;
@@ -497,9 +499,10 @@ bool ChmThread::ExitAllThreads(void)
 
 bool ChmThread::IsThreadRun(void)
 {
-	PCHMTHWP_PARAM	exit_pthparam;
-	bool			result = false;
+	bool	result = false;
 	while(true){
+		PCHMTHWP_PARAM	exit_pthparam;
+
 		while(!fullock::flck_trylock_noshared_mutex(&list_lockval));// LOCK
 
 		// search exit thread and wait for exiting it.

--- a/lib/chmthread.h
+++ b/lib/chmthread.h
@@ -117,7 +117,7 @@ class ChmThread
 		bool WaitExitThread(PCHMTHWP_PARAM thread_param);
 
 	public:
-		ChmThread(const char* pname = NULL);
+		explicit ChmThread(const char* pname = NULL);
 		virtual ~ChmThread();
 
 		bool HasThread(void) const { return (0 < chmthlist.size()); }

--- a/tests/chmpxbench.cc
+++ b/tests/chmpxbench.cc
@@ -146,7 +146,7 @@ static inline char* programname(char* prgpath)
 
 static bool SetStringBytes(string& str, size_t totallength, char ch)
 {
-	if(totallength <= 0){
+	if(totallength == 0){
 		return false;
 	}
 	if((str.length() + 1) == totallength){
@@ -360,7 +360,7 @@ static bool SetBenchOptions(ChmOpts& opts, BOPTS& benchopts)
 //---------------------------------------------------------
 // Common Mmap file
 //---------------------------------------------------------
-static int OpenBenchFile(const string filepath, size_t& totalsize, bool is_create)
+static int OpenBenchFile(const string& filepath, size_t& totalsize, bool is_create)
 {
 	int	fd;
 

--- a/tests/chmpxconftest.cc
+++ b/tests/chmpxconftest.cc
@@ -133,27 +133,27 @@ void print_initial_datas(void)
 	printf("================================================================\n");
 	printf(" Default datas and size for SHM\n");
 	printf("----------------------------------------------------------------\n");
-	printf("CHMPX                %zd bytes\n", sizeof(CHMPX));
-	printf("CHMPXLIST            %zd bytes\n", sizeof(CHMPXLIST));
-	printf("CHMSTAT              %zd bytes\n", sizeof(CHMSTAT));
-	printf("CHMPXMAN             %zd bytes\n", sizeof(CHMPXMAN));
-	printf("MQMSGHEAD            %zd bytes\n", sizeof(MQMSGHEAD));
-	printf("MQMSGHEADLIST        %zd bytes\n", sizeof(MQMSGHEADLIST));
-	printf("CHMINFO              %zd bytes\n", sizeof(CHMINFO));
-	printf("CHMLOGRAW            %zd bytes\n", sizeof(CHMLOGRAW));
-	printf("CHMLOG               %zd bytes\n", sizeof(CHMLOG));
-	printf("CHMSHM               %zd bytes\n", sizeof(CHMSHM));
+	printf("CHMPX                %zu bytes\n", sizeof(CHMPX));
+	printf("CHMPXLIST            %zu bytes\n", sizeof(CHMPXLIST));
+	printf("CHMSTAT              %zu bytes\n", sizeof(CHMSTAT));
+	printf("CHMPXMAN             %zu bytes\n", sizeof(CHMPXMAN));
+	printf("MQMSGHEAD            %zu bytes\n", sizeof(MQMSGHEAD));
+	printf("MQMSGHEADLIST        %zu bytes\n", sizeof(MQMSGHEADLIST));
+	printf("CHMINFO              %zu bytes\n", sizeof(CHMINFO));
+	printf("CHMLOGRAW            %zu bytes\n", sizeof(CHMLOGRAW));
+	printf("CHMLOG               %zu bytes\n", sizeof(CHMLOG));
+	printf("CHMSHM               %zu bytes\n", sizeof(CHMSHM));
 	printf("\n");
-	printf("CHMPXLIST[def]       %zd bytes\n", sizeof(CHMPXLIST) * DEFAULT_CHMPX_COUNT);
-	printf("MQMSGHEADLIST[def]   %zd bytes\n", sizeof(MQMSGHEADLIST) * DEFAULT_CLIENT_MQ_CNT);
-	printf("CHMLOGRAW[def]       %zd bytes\n", sizeof(CHMLOGRAW) * DEFAULT_HISTLOG_COUNT);
+	printf("CHMPXLIST[def]       %zu bytes\n", sizeof(CHMPXLIST) * DEFAULT_CHMPX_COUNT);
+	printf("MQMSGHEADLIST[def]   %zu bytes\n", sizeof(MQMSGHEADLIST) * DEFAULT_CLIENT_MQ_CNT);
+	printf("CHMLOGRAW[def]       %zu bytes\n", sizeof(CHMLOGRAW) * DEFAULT_HISTLOG_COUNT);
 	printf("\n");
-	printf("CHMPXLIST[max]       %zd bytes\n", sizeof(CHMPXLIST) * MAX_CHMPX_COUNT);
-	printf("MQMSGHEADLIST[max]   %zd bytes\n", sizeof(MQMSGHEADLIST) * MAX_CLIENT_MQ_CNT);
-	printf("CHMLOGRAW[max]       %zd bytes\n", sizeof(CHMLOGRAW) * MAX_HISTLOG_COUNT);
+	printf("CHMPXLIST[max]       %zu bytes\n", sizeof(CHMPXLIST) * MAX_CHMPX_COUNT);
+	printf("MQMSGHEADLIST[max]   %zu bytes\n", sizeof(MQMSGHEADLIST) * MAX_CLIENT_MQ_CNT);
+	printf("CHMLOGRAW[max]       %zu bytes\n", sizeof(CHMLOGRAW) * MAX_HISTLOG_COUNT);
 	printf("\n");
-	printf("total[def]           %zd bytes\n", sizeof(CHMSHM) + sizeof(CHMPXLIST) * DEFAULT_CHMPX_COUNT + sizeof(MQMSGHEADLIST) * DEFAULT_CLIENT_MQ_CNT + sizeof(CHMLOGRAW) * DEFAULT_HISTLOG_COUNT);
-	printf("total[max]           %zd bytes\n", sizeof(CHMSHM) + sizeof(CHMPXLIST) * MAX_CHMPX_COUNT + sizeof(MQMSGHEADLIST) * MAX_CLIENT_MQ_CNT + sizeof(CHMLOGRAW) * MAX_HISTLOG_COUNT);
+	printf("total[def]           %zu bytes\n", sizeof(CHMSHM) + sizeof(CHMPXLIST) * DEFAULT_CHMPX_COUNT + sizeof(MQMSGHEADLIST) * DEFAULT_CLIENT_MQ_CNT + sizeof(CHMLOGRAW) * DEFAULT_HISTLOG_COUNT);
+	printf("total[max]           %zu bytes\n", sizeof(CHMSHM) + sizeof(CHMPXLIST) * MAX_CHMPX_COUNT + sizeof(MQMSGHEADLIST) * MAX_CLIENT_MQ_CNT + sizeof(CHMLOGRAW) * MAX_HISTLOG_COUNT);
 	printf("\n");
 
 	PCHMSHM	shm = new CHMSHM;
@@ -273,8 +273,7 @@ int main(int argc, char** argv)
 	sigprocmask(SIG_SETMASK, &sigset, NULL);
 
 	// Loop
-	bool	isloop = true;
-	while(isloop){
+	while(true){
 		struct epoll_event	events[32];
 		int					max_events	= 32;
 		int					timeout		= 1000;					// 1s (ex, shmproxy is 100ms)

--- a/tests/chmpxstreamtest.cc
+++ b/tests/chmpxstreamtest.cc
@@ -117,18 +117,18 @@ static bool TestServerSide(ChmCntrl& chmobj)
 	string		strVal;
 	string		strRVal;
 	string		strRVal8192;
-	char		buff;
-	int			ival;
-	long		lval;
-	bool		is_reply;
-	bool		is_error;
 	for(int cnt = 0; cnt < 256; ++cnt){
 		strRVal8192 += STREAM_VAL32_STR;
 	}
 
 	while(true){
+		char	buff;
+		int		ival;
+		long	lval;
+		bool	is_reply;
+		bool	is_error;
+
 		is_error = false;
-		is_reply = false;
 		buff	= '\0';
 		ival	= -1;
 		lval	= -1;


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Added cppcheck
We made use of cppcheck.  
cppcheck will automatically run on TravisCI.  
If you want to run it manually, please use `make cppcheck`.  

In this PR, we corrected errors etc. detected by cppcheck.

#### NOTE
cppcheck depends on the OS of the build environment, and different versions are used for each.  
This PR is trying to eliminate this difference.  

And building chmpx on Travis CI is running in several OS.  
Depending on the OS(CentOS, ubuntu, debian, fedora), different cppcheck versions are installed.  
Certain versions of cppcheck are incompatible with the chmpx template source code and are very poor performance on the VM or container(Travis CI).  
On problematic versions, timeout error on Travis CI.  
To avoid this we skip only specific versions of cppcheck on travis.  
Even if we skip a specific version of the cppcheck, it will be tested with a combination of other versions and OS.  
When running Travis, the TRAVIS_TAG environment variable is set, and this environment variable is used for judgment.  

Currently, debian uses cppcheck 1.76, and CentOS6 uses 1.63, there is a problem with this old version, skipping this.  
If debian/etc will support 1.8x or later versions in the future, this skipped process will be unnecessary.
