### PR TITLE
Updated files for release 1.0.68

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+chmpx (1.0.68) unstable; urgency=low
+
+  * Fixed codes for cppcheck 1.87 - #23
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Tue, 12 Mar 2019 16:51:53 +0900
+
 chmpx (1.0.67) unstable; urgency=low
 
   * Fixed misspelling, and etc - #20


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Changes from 1.0.67 to 1.0.68
- Fixed codes for cppcheck 1.87 - #23

