### PR TITLE
Enhanced node discovery of hostnames and IP addresses

### DIFF
--- a/lib/chmcomstructure.h
+++ b/lib/chmcomstructure.h
@@ -998,17 +998,17 @@ typedef struct com_packet{
 		if(chm_debug_mode >= CHMDBG_DUMP){ \
 			if(COM_PX2PX == (pComPkt)->head.type){ \
 				PPXCOM_ALL	pComAll = CVT_COM_ALL_PTR_PXCOMPKT((pComPkt)); \
-				MSG_CHMPRN("%s COMPKT type(%s) : PXCOM_ALL type(%s).", action ? action : "", STRCOMTYPE((pComPkt)->head.type), STRPXCOMTYPE(pComAll->val_head.type)); \
+				MSG_CHMPRN("%s COMPKT type(%s) : PXCOM_ALL type(%s).", (CHMEMPTYSTR(action) ? "" : action), STRCOMTYPE((pComPkt)->head.type), STRPXCOMTYPE(pComAll->val_head.type)); \
 			}else if(COM_C2C == (pComPkt)->head.type){ \
-				MSG_CHMPRN("%s COMPKT type(%s) : COM_C2C type(%s).", action ? action : "", STRCOMTYPE((pComPkt)->head.type), STRCOMC2CTYPE((pComPkt)->head.c2ctype)); \
+				MSG_CHMPRN("%s COMPKT type(%s) : COM_C2C type(%s).", (CHMEMPTYSTR(action) ? "" : action), STRCOMTYPE((pComPkt)->head.type), STRCOMC2CTYPE((pComPkt)->head.c2ctype)); \
 			}else{ \
-				MSG_CHMPRN("%s COMPKT type(%s).", action ? action : "", STRCOMTYPE((pComPkt)->head.type)); \
+				MSG_CHMPRN("%s COMPKT type(%s).", (CHMEMPTYSTR(action) ? "" : action), STRCOMTYPE((pComPkt)->head.type)); \
 			} \
 		}
 
 #define	DUMPCOM_COMPKT(headmsg, pComPkt)	\
 		if(chm_debug_mode >= CHMDBG_DUMP){ \
-			fprintf((chm_dbg_fp ? chm_dbg_fp : stderr), "DUMP COMPKT(%s) = {\n",					headmsg ? headmsg : "notag"); \
+			fprintf((chm_dbg_fp ? chm_dbg_fp : stderr), "DUMP COMPKT(%s) = {\n",					(CHMEMPTYSTR(headmsg) ? "notag" : headmsg)); \
 			fprintf((chm_dbg_fp ? chm_dbg_fp : stderr), "  head              = {\n"); \
 			fprintf((chm_dbg_fp ? chm_dbg_fp : stderr), "    version         = 0x%016" PRIx64 "\n",	(pComPkt)->head.version); \
 			fprintf((chm_dbg_fp ? chm_dbg_fp : stderr), "    type            = 0x%016" PRIx64 "\n",	(pComPkt)->head.type); \
@@ -1037,7 +1037,7 @@ typedef struct com_packet{
 
 #define	DUMPCOM_PXCLT(headmsg, pCltAll)	\
 		if(chm_debug_mode >= CHMDBG_DUMP){ \
-			fprintf((chm_dbg_fp ? chm_dbg_fp : stderr), "DUMP PXCTL(%s) = {\n",						headmsg ? headmsg : "notag"); \
+			fprintf((chm_dbg_fp ? chm_dbg_fp : stderr), "DUMP PXCTL(%s) = {\n",						(CHMEMPTYSTR(headmsg) ? "notag" : headmsg)); \
 			fprintf((chm_dbg_fp ? chm_dbg_fp : stderr), "  val_head          = {\n"); \
 			fprintf((chm_dbg_fp ? chm_dbg_fp : stderr), "    type            = 0x%016" PRIx64 "\n",	(pCltAll)->val_head.type); \
 			fprintf((chm_dbg_fp ? chm_dbg_fp : stderr), "    length          = 0x%016" PRIx64 "\n",	(pCltAll)->val_head.length); \

--- a/lib/chmeventshm.cc
+++ b/lib/chmeventshm.cc
@@ -78,8 +78,7 @@ bool ChmEventShm::CheckProcessRunning(void* common_param, chmthparam_t wp_param)
 		WAN_CHMPRN("Failed to get pid list.");
 		return true;	// finish.
 	}
-	// cppcheck-suppress stlSize
-	if(0 == pidlist.size()){
+	if(pidlist.empty()){
 		// why?(nothing to do)
 		return true;
 	}
@@ -93,8 +92,7 @@ bool ChmEventShm::CheckProcessRunning(void* common_param, chmthparam_t wp_param)
 				down_pids.push_back(*iter);
 			}
 		}
-		// cppcheck-suppress stlSize
-		if(0 != down_pids.size()){
+		if(!down_pids.empty()){
 			break;
 		}
 		// no down process

--- a/lib/chmimdata.h
+++ b/lib/chmimdata.h
@@ -216,8 +216,7 @@ class ChmIMData
 		bool GetServerBase(chmpxid_t chmpxid, CHMPXSSL& ssl) const;
 		bool GetServerSocks(chmpxid_t chmpxid, socklist_t& socklist, int& ctlsock) const;
 		bool GetServerSock(chmpxid_t chmpxid, socklist_t& socklist) const { int tmp; return GetServerSocks(chmpxid, socklist, tmp); }
-		// cppcheck-suppress stlSize
-		bool IsConnectServer(chmpxid_t chmpxid) const { socklist_t tmpsocklist; return (GetServerSock(chmpxid, tmpsocklist) && 0 < tmpsocklist.size()); }
+		bool IsConnectServer(chmpxid_t chmpxid) const { socklist_t tmpsocklist; return (GetServerSock(chmpxid, tmpsocklist) && !tmpsocklist.empty()); }
 		bool GetServerCtlSock(chmpxid_t chmpxid, int& ctlsock) const { socklist_t tmplist; return GetServerSocks(chmpxid, tmplist, ctlsock); }
 		bool GetServerHash(chmpxid_t chmpxid, chmhash_t& base, chmhash_t& pending) const;
 		bool GetServerBaseHash(chmpxid_t chmpxid, chmhash_t& hash) const { chmhash_t tmp; return GetServerHash(chmpxid, hash, tmp); }
@@ -239,8 +238,7 @@ class ChmIMData
 		long GetSlaveChmpxIds(chmpxidlist_t& list) const;
 		bool GetSlaveBase(chmpxid_t chmpxid, std::string& name, short& ctlport) const;
 		bool GetSlaveSock(chmpxid_t chmpxid, socklist_t& socklist) const;
-		// cppcheck-suppress stlSize
-		bool IsConnectSlave(chmpxid_t chmpxid) const { socklist_t tmplist; return (GetSlaveSock(chmpxid, tmplist) && 0 < tmplist.size()); }
+		bool IsConnectSlave(chmpxid_t chmpxid) const { socklist_t tmplist; return (GetSlaveSock(chmpxid, tmplist) && !tmplist.empty()); }
 		chmpxsts_t GetSlaveStatus(chmpxid_t chmpxid) const;
 
 		bool SetServerSocks(chmpxid_t chmpxid, int sock, int ctlsock, int type);

--- a/lib/chmkvp.h
+++ b/lib/chmkvp.h
@@ -42,7 +42,7 @@ class ChmBinData
 
 	public:
 		ChmBinData(unsigned char* bydata = NULL, size_t bylength = 0L, bool is_duplicate = false);
-		ChmBinData(PCHMBIN pchmbin, bool is_duplicate = false);
+		ChmBinData(PCHMBIN pchmbin, bool is_duplicate);
 		virtual ~ChmBinData();
 
 		void Clear(void);
@@ -79,7 +79,7 @@ class ChmKVPair
 	public:
 		ChmKVPair(unsigned char* bykey = NULL, size_t keylen = 0L, unsigned char* byval = NULL, size_t vallen = 0L, bool is_duplicate = false);
 		ChmKVPair(ChmBinData* pKey, ChmBinData* pValue, bool is_duplicate = false);
-		ChmKVPair(PCHMKVP pkvp, bool is_duplicate = false);
+		ChmKVPair(PCHMKVP pkvp, bool is_duplicate);
 		virtual ~ChmKVPair();
 
 		void Clear(void);

--- a/lib/chmnetdb.cc
+++ b/lib/chmnetdb.cc
@@ -30,6 +30,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
+#include <ifaddrs.h>
 #include <string>
 
 #include "chmcommon.h"
@@ -38,6 +39,118 @@
 #include "chmnetdb.h"
 
 using namespace	std;
+
+//---------------------------------------------------------
+// Utilities
+//---------------------------------------------------------
+static void AddUniqueStringToList(const string& str, strlst_t& list, bool is_clear)
+{
+	if(is_clear){
+		list.clear();
+	}
+	if(str.empty()){
+		return;
+	}
+	for(strlst_t::const_iterator iter = list.begin(); iter != list.end(); ++iter){
+		if((*iter) == str){
+			// already has same string.
+			return;
+		}
+	}
+	list.push_back(str);
+}
+
+static void AddUniqueStringListToList(const strlst_t& addlist, strlst_t& list, bool is_clear)
+{
+	if(is_clear){
+		list.clear();
+	}
+	for(strlst_t::const_iterator iter1 = addlist.begin(); iter1 != addlist.end(); ++iter1){
+		if(iter1->empty()){
+			continue;
+		}
+		bool	found = false;
+		for(strlst_t::const_iterator iter2 = list.begin(); iter2 != list.end(); ++iter2){
+			if((*iter1) == (*iter2)){
+				found = true;
+				break;
+			}
+		}
+		if(!found){
+			list.push_back(*iter1);
+		}
+	}
+}
+
+// [NOTE]
+// The IPv6 address string may include zone index(ex. "fe80::a00:27ff:fe51:2336%eth1").
+// This method inserts the address string from which zone index is deleted at the detected position.
+// This is necessary when matching.
+// 
+static void ExpandZoneIndexInList(strlst_t& list)
+{
+	for(strlst_t::iterator iter = list.begin(); iter != list.end(); ++iter){
+		if(string::npos != iter->find('%')){
+			string	nozoneindex = ChmNetDb::GetNoZoneIndexIpAddress(*iter);
+			++iter;
+			if(list.end() == iter){
+				// insert to end of list
+				list.push_back(nozoneindex);
+				break;
+			}else{
+				iter = list.insert(iter, nozoneindex);
+			}
+		}
+	}
+}
+
+static void RemoveZoneIndexInList(strlst_t& list)
+{
+	for(strlst_t::iterator iter = list.begin(); iter != list.end(); ){
+		if(string::npos != iter->find('%')){
+			string	nozi = iter->substr(0, iter->find('%'));
+			iter = list.erase(iter);
+			iter = list.insert(iter, nozi);
+		}else{
+			++iter;
+		}
+	}
+}
+
+static void RemoveLocalhostKeys(strlst_t& list)
+{
+	for(strlst_t::iterator iter = list.begin(); iter != list.end(); ){
+		if(ChmNetDb::IsLocalhostKeyword(iter->c_str())){
+			iter = list.erase(iter);
+		}else{
+			++iter;
+		}
+	}
+}
+
+static bool RemoveLocalhostInCache(CHMNDBCACHE& data)
+{
+	// check localhost(or 127.0.0.1 or ::1) and remove it.
+	strlst_t::iterator	iter;
+	bool				found = false;
+	for(iter = data.hostnames.begin(); data.hostnames.end() != iter; ){
+		if((*iter) == "localhost"){
+			found	= true;
+			iter	= data.hostnames.erase(iter);
+		}else{
+			++iter;
+		}
+	}
+	for(iter = data.ipaddresses.begin(); data.ipaddresses.end() != iter; ){
+		if(ChmNetDb::IsLocalhostKeyword(iter->c_str())){
+			found	= true;
+			iter	= data.ipaddresses.erase(iter);
+		}else{
+			++iter;
+		}
+	}
+	return found;
+}
 
 //---------------------------------------------------------
 // Class variables
@@ -64,7 +177,6 @@ time_t ChmNetDb::SetTimeout(time_t value)
 	return old;
 }
 
-
 bool ChmNetDb::Clear(void)
 {
 	return ChmNetDb::Get()->ClearEx();
@@ -77,9 +189,29 @@ bool ChmNetDb::CacheOut(void)
 
 bool ChmNetDb::GetLocalHostname(string& hostname)
 {
+	// [NOTE]
+	// calling GetHostname with "localhost" always returns full local hostname.
+	//
 	if(!ChmNetDb::Get()->GetHostname("localhost", hostname, true)){
 		MSG_CHMPRN("Could not get localhost to global hostname.");
 		return false;
+	}
+	return true;
+}
+
+bool ChmNetDb::GetLocalHostnameList(strlst_t& hostnames)
+{
+	if(!ChmNetDb::Get()->GetHostnameList("localhost", hostnames, true)){
+		MSG_CHMPRN("Could not get localhost to hostname list.");
+		return false;
+	}
+	return true;
+}
+
+bool ChmNetDb::GetLocalHostList(strlst_t& hostinfo, bool remove_localhost)
+{
+	if(!ChmNetDb::Get()->GetAllHostList("localhost", hostinfo, true)){
+		WAN_CHMPRN("Could not get localhost to hostname and ip address list.");
 	}
 	return true;
 }
@@ -120,6 +252,7 @@ bool ChmNetDb::CvtAddrInfoToIpAddress(const struct sockaddr_storage* info, sockl
 	}
 
 	// addrinfo -> normalized ipaddress
+	memset(&ipaddress, 0, sizeof(ipaddress));
 	if(0 != (result = getnameinfo(reinterpret_cast<const struct sockaddr*>(info), infolen, ipaddress, sizeof(ipaddress), NULL, 0, NI_NUMERICHOST | NI_NUMERICSERV))){
 		MSG_CHMPRN("Could not convert addrinfo to normalized ipaddress, errno=%d.", result);
 		return false;
@@ -145,6 +278,7 @@ bool ChmNetDb::CvtSockToLocalPort(int sock, short& port)
 
 	char	szport[NI_MAXHOST];
 	int		result;
+	memset(&szport, 0, sizeof(szport));
 	if(0 != (result = getnameinfo(reinterpret_cast<struct sockaddr*>(&info), infolen, NULL, 0, szport, sizeof(szport), NI_NUMERICHOST | NI_NUMERICSERV))){
 		MSG_CHMPRN("Could not convert addrinfo to port number, errno=%d.", result);
 		return false;
@@ -170,6 +304,7 @@ bool ChmNetDb::CvtSockToPeerPort(int sock, short& port)
 
 	char	szport[NI_MAXHOST];
 	int		result;
+	memset(&szport, 0, sizeof(szport));
 	if(0 != (result = getnameinfo(reinterpret_cast<struct sockaddr*>(&info), infolen, NULL, 0, szport, sizeof(szport), NI_NUMERICHOST | NI_NUMERICSERV))){
 		MSG_CHMPRN("Could not convert addrinfo to port number, errno=%d.", result);
 		return false;
@@ -206,15 +341,49 @@ bool ChmNetDb::CvtV4MappedAddrInfo(struct sockaddr_storage* info, socklen_t& add
 	return true;
 }
 
+void ChmNetDb::FreeAddrInfoList(addrinfolist_t& infolist)
+{
+	for(addrinfolist_t::const_iterator iter = infolist.begin(); iter != infolist.end(); ++iter){
+		struct addrinfo*	tmp = *iter;
+		freeaddrinfo(tmp);
+	}
+	infolist.clear();
+}
+
+string ChmNetDb::GetNoZoneIndexIpAddress(const string& ipaddr)
+{
+	// if IP address is IPv6 with zone index, we set both to cache.
+	string::size_type	pos;
+	if(string::npos != (pos = ipaddr.find('%'))){
+		return ipaddr.substr(0, pos);
+	}
+	return ipaddr;
+}
+
+bool ChmNetDb::IsLocalhostKeyword(const char* host)
+{
+	if(CHMEMPTYSTR(host)){
+		return false;
+	}
+	if(	0 == strcmp(host, "localhost")	||
+		0 == strcmp(host, "127.0.0.1")	||
+		0 == strcmp(host, "::1")		||
+		0 == strncmp(host, "::1%", 4)	)
+	{
+		return true;
+	}
+	return false;
+}
+
 //---------------------------------------------------------
 // Methods
 //---------------------------------------------------------
-ChmNetDb::ChmNetDb() : timeout(ChmNetDb::ALIVE_TIME), fulllocalname(""), localname("")
+ChmNetDb::ChmNetDb() : timeout(ChmNetDb::ALIVE_TIME)
 {
 	static ChmNetDb*	pnetdb = NULL;		// for checking initializing
 	if(!pnetdb){
 		pnetdb = this;
-		InitializeLocalHostName();			// initializing
+		InitializeLocalHostInfo();			// initializing
 	}
 }
 
@@ -223,56 +392,136 @@ ChmNetDb::~ChmNetDb()
 	ClearEx();
 }
 
-bool ChmNetDb::InitializeLocalHostName(void)
+bool ChmNetDb::InitializeLocalHostInfo(void)
+{
+	ClearEx();								// clear all cache
+	fulllocalname.erase();
+	localaddrs.clear();
+	localnames.clear();
+
+	if(!InitializeLocalHostIpAddresses()){
+		WAN_CHMPRN("Obtaining the IP address of the local interfaces may have failed, but continue...");
+	}
+	if(!InitializeLocalHostnames()){
+		WAN_CHMPRN("Obtaining the local hostnames may have failed, but continue...");
+	}
+	return true;
+}
+
+bool ChmNetDb::InitializeLocalHostIpAddresses()
+{
+	struct ifaddrs*	ifaddr;
+	char			ipaddr[NI_MAXHOST];
+
+	// get ip addresses on interface
+	memset(&ipaddr, 0, sizeof(ipaddr));
+	if(-1 == getifaddrs(&ifaddr)){
+		ERR_CHMPRN("Failed to get local interface addresses by getifaddrs : errno=%d", errno);
+		return false;
+	}
+
+	// get all ip addresses
+	for(struct ifaddrs* tmp_ifaddr = ifaddr; NULL != tmp_ifaddr; tmp_ifaddr = tmp_ifaddr->ifa_next){
+		if(NULL == tmp_ifaddr->ifa_addr){
+			continue;
+		}
+		if(AF_INET == tmp_ifaddr->ifa_addr->sa_family || AF_INET6 == tmp_ifaddr->ifa_addr->sa_family){
+			memset(ipaddr, 0, sizeof(ipaddr));
+			socklen_t	salen	= (AF_INET == tmp_ifaddr->ifa_addr->sa_family) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
+			int			result	= getnameinfo(tmp_ifaddr->ifa_addr, salen, ipaddr, sizeof(ipaddr), NULL, 0, NI_NUMERICHOST);
+			if(0 == result){
+				if(!CHMEMPTYSTR(ipaddr)){
+					MSG_CHMPRN("Found local interface IP address : %s", ipaddr);
+
+					AddUniqueStringToList(string(ipaddr), localaddrs, false);
+
+					// add cache without hostnames
+					IpAddressAddCache(string(ipaddr), string(""), true);
+				}else{
+					WAN_CHMPRN("Found local interface IP address, but it is empty.");
+				}
+			}else{
+				WAN_CHMPRN("Failed to get local interface IP address by getnameinfo : %s", gai_strerror(result));
+			}
+		}
+	}
+	freeifaddrs(ifaddr);
+
+	return true;
+}
+
+bool ChmNetDb::InitializeLocalHostnames()
 {
 	struct addrinfo		hints;
 	struct addrinfo*	res_info = NULL;
 	struct addrinfo*	tmpaddrinfo;
-	char				hostname[NI_MAXHOST];
-	int					result;
 	struct utsname		buf;
+	char				hostname[NI_MAXHOST];
+	char				ipaddr[NI_MAXHOST];
+	int					result;
 
 	// Get local hostname by uname
 	if(-1 == uname(&buf)){
 		ERR_CHMPRN("Failed to get own host(node) name, errno=%d", errno);
 		return false;
 	}
+	if(CHMEMPTYSTR(buf.nodename)){
+		ERR_CHMPRN("Got own host(node) name, but it is empty.");
+		return false;
+	}
 	fulllocalname = buf.nodename;
 
+	// add cache without ip addresses
+	HostnammeAddCache(fulllocalname, string(""), true);
+
+	// local hostname -> addrinfo
 	memset(&hints, 0, sizeof(hints));
 	hints.ai_flags		= AI_CANONNAME;
 	hints.ai_family		= AF_UNSPEC;
 	hints.ai_socktype	= SOCK_STREAM;
-
-	// local hostname -> addrinfo
 	if(0 != (result = getaddrinfo(buf.nodename, NULL, &hints, &res_info)) || !res_info){				// port is NULL
 		MSG_CHMPRN("Could not get addrinfo from %s, errno=%d.", buf.nodename, result);
 		if(res_info){
 			freeaddrinfo(res_info);
 		}
-		return false;
+		// already set full local hostname, then returns true.
+		return true;
 	}
 
 	// addrinfo(list) -> hostname
+	bool	is_fulllocalname;
 	for(tmpaddrinfo = res_info; tmpaddrinfo; tmpaddrinfo = tmpaddrinfo->ai_next){
-		if(0 != (result = getnameinfo(tmpaddrinfo->ai_addr, tmpaddrinfo->ai_addrlen, hostname, sizeof(hostname), NULL, 0, NI_NAMEREQD | NI_NUMERICSERV))){
-			MSG_CHMPRN("Could not get hostname %s, errno=%d.", buf.nodename, result);
+		memset(hostname, 0, sizeof(hostname));
+		if(0 == (result = getnameinfo(tmpaddrinfo->ai_addr, tmpaddrinfo->ai_addrlen, hostname, sizeof(hostname), NULL, 0, NI_NAMEREQD | NI_NUMERICSERV))){
+			if(!CHMEMPTYSTR(hostname)){
+				// When local hostname without domain name is set in /etc/hosts, "hostname" is short name.
+				// (if other server name is set, this class do not care it.)
+				//
+				MSG_CHMPRN("Found another local hostname : %s", hostname);
+
+				if(0 != strcmp(fulllocalname.c_str(), hostname)){
+					is_fulllocalname = false;
+				}else{
+					is_fulllocalname = true;
+				}
+				AddUniqueStringToList(string(hostname), localnames, false);
+
+				// add cache
+				memset(&ipaddr, 0, sizeof(ipaddr));
+				if(0 == (result = getnameinfo(tmpaddrinfo->ai_addr, tmpaddrinfo->ai_addrlen, ipaddr, sizeof(ipaddr), NULL, 0, NI_NUMERICHOST))){
+					HostnammeAddCache(string(hostname), string(ipaddr), true);
+
+					if(!is_fulllocalname){
+						HostnammeAddCache(fulllocalname, string(ipaddr), true);
+					}
+				}
+			}else{
+				WAN_CHMPRN("Found another local hostname, but it is empty.");
+			}
 		}else{
-			break;
+			MSG_CHMPRN("Failed to get another local hostname %s, errno=%d.", buf.nodename, result);
 		}
 	}
-	if(!tmpaddrinfo){
-		MSG_CHMPRN("Could not get hostname %s.", buf.nodename);
-		freeaddrinfo(res_info);
-		return false;
-	}
-
-	// When local hostname without domain name is set in /ec/hosts,
-	// "hostname" is short name.
-	// (if other server name is set, this class do not care it.)
-	//
-	localname = hostname;
-
 	freeaddrinfo(res_info);
 
 	return true;
@@ -289,12 +538,12 @@ bool ChmNetDb::ClearEx(void)
 
 bool ChmNetDb::CacheOutEx(void)
 {
-	time_t	timeouted = time(NULL) + timeout;
+	time_t	now = time(NULL);
 
 	while(!fullock::flck_trylock_noshared_mutex(&ChmNetDb::lockval));
 
 	for(chmndbmap_t::iterator iter = cachemap.begin(); iter != cachemap.end(); ){
-		if(timeouted < iter->second.cached_time){
+		if(0 != iter->second.cached_time && (iter->second.cached_time + timeout) < now){
 			cachemap.erase(iter++);
 		}else{
 			++iter;
@@ -305,72 +554,189 @@ bool ChmNetDb::CacheOutEx(void)
 	return true;
 }
 
-// [TODO]
-// If one FQDN has many address(ex. it specifies in /etc/hosts), this method returns one address.
-// But this should return all names and addresses.
-// If it is needed, should use res_query etc for checking DNS entry.
+// [NOTE]
+// This method is reentrant.
+// If called as re-entry, it will not be re-entered.
 //
-bool ChmNetDb::GetHostAddressInfo(const char* target, string& strhostname, string& stripaddress)
+bool ChmNetDb::RawAddCache(const string& target, const strlst_t& addlist, bool is_noexp, bool is_hostname, bool is_reentrant)
 {
-	struct addrinfo		hints;
-	struct addrinfo*	res_info = NULL;
-	struct addrinfo*	tmpaddrinfo;
-	char				hostname[NI_MAXHOST];
-	char				ipaddress[NI_MAXHOST];
-	int					result;
-
-	if(CHMEMPTYSTR(target)){
-		ERR_CHMPRN("Parameter is wrong.");
-		return false;
+	if(!is_reentrant){
+		while(!fullock::flck_trylock_noshared_mutex(&ChmNetDb::lockval));
 	}
+	chmndbmap_t::iterator	iter	= cachemap.find(target);
+	bool					result	= true;
+	bool					found;
 
-	memset(&hints, 0, sizeof(hints));
-	hints.ai_flags		= AI_CANONNAME;
-	hints.ai_family		= AF_UNSPEC;
-	hints.ai_socktype	= SOCK_STREAM;
+	if(is_hostname){
+		strlst_t	newipaddrs;
+		if(cachemap.end() != iter){
+			// found in cache
+			// merge ip addresses
+			for(strlst_t::const_iterator additer = addlist.begin(); addlist.end() != additer; ++additer){
+				found = false;
+				if(additer->empty()){
+					continue;
+				}
+				for(strlst_t::const_iterator ipiter = iter->second.ipaddresses.begin(); iter->second.ipaddresses.end() != ipiter; ++ipiter){
+					if((*ipiter) == (*additer)){
+						found = true;
+						break;
+					}
+				}
+				if(!found){
+					AddUniqueStringToList(*additer, iter->second.ipaddresses, false);
+					AddUniqueStringToList(*additer, newipaddrs, false);
+				}
+			}
+			// add hostanme
+			found = false;
+			for(strlst_t::const_iterator hostiter = iter->second.hostnames.begin(); iter->second.hostnames.end() != hostiter; ++hostiter){
+				if((*hostiter) == target){
+					found = true;
+					break;
+				}
+			}
+			if(!found){
+				AddUniqueStringToList(target, iter->second.hostnames, false);
+			}
+			// update timeout
+			iter->second.cached_time = (is_noexp && 0 == iter->second.cached_time) ? 0 : time(NULL);
 
-	// target -> addrinfo
-	if(0 != getaddrinfo(target, NULL, &hints, &res_info) || !res_info){				// port is NULL
-		return false;
-	}
-
-	// addrinfo(list) -> hostname
-	for(tmpaddrinfo = res_info; tmpaddrinfo; tmpaddrinfo = tmpaddrinfo->ai_next){
-		if(0 != (result = getnameinfo(tmpaddrinfo->ai_addr, tmpaddrinfo->ai_addrlen, hostname, sizeof(hostname), NULL, 0, NI_NAMEREQD | NI_NUMERICSERV))){
-			MSG_CHMPRN("Could not get hostname %s, errno=%d.", target, result);
 		}else{
-			break;
-		}
-	}
-	if(!tmpaddrinfo){
-		MSG_CHMPRN("Could not get hostname %s.", target);
-		freeaddrinfo(res_info);
-		return false;
-	}
+			// not found, add new cache
+			CHMNDBCACHE	newcache;
+			AddUniqueStringListToList(addlist, newcache.ipaddresses, true);
+			AddUniqueStringToList(target, newcache.hostnames, true);
+			newcache.cached_time= is_noexp ? 0 : time(NULL);
 
-	// addrinfo -> normalized ipaddress
-	for(tmpaddrinfo = res_info; tmpaddrinfo; tmpaddrinfo = tmpaddrinfo->ai_next){
-		if(0 != (result = getnameinfo(tmpaddrinfo->ai_addr, tmpaddrinfo->ai_addrlen, ipaddress, sizeof(ipaddress), NULL, 0, NI_NUMERICHOST | NI_NUMERICSERV))){
-			MSG_CHMPRN("Could not convert normalized ipaddress  %s, errno=%d.", target, result);
-		}else{
-			break;
-		}
-	}
-	freeaddrinfo(res_info);
-	if(!tmpaddrinfo){
-		MSG_CHMPRN("Could not get ipaddress %s.", target);
-		return false;
-	}
+			cachemap[target]	= newcache;
 
-	// if short local hostname, returns fully hostname.
-	if(hostname == localname){
-		strhostname	= fulllocalname;
+			AddUniqueStringListToList(addlist, newipaddrs, false);
+		}
+
+		// add ip addresses(re-entrant)
+		if(!is_reentrant){
+			strlst_t	addhostnames;
+			addhostnames.push_back(target);
+			for(strlst_t::const_iterator ipiter2 = newipaddrs.begin(); newipaddrs.end() != ipiter2; ++ipiter2){
+				if(!RawAddCache(*ipiter2, addhostnames, is_noexp, false, true)){
+					result = false;
+				}
+				// if IP address is IPv6 with zone index, we set both to cache.
+				if(string::npos != ipiter2->find('%')){
+					string	nozi = ChmNetDb::GetNoZoneIndexIpAddress(*ipiter2);
+					if(!RawAddCache(nozi, addhostnames, is_noexp, false, true)){
+						result = false;
+					}
+				}
+			}
+		}
 	}else{
-		strhostname	= hostname;
-	}
-	stripaddress= ipaddress;
+		strlst_t	newhostnames;
+		if(cachemap.end() != iter){
+			// found in cache
+			// merge hostnames
+			for(strlst_t::const_iterator additer = addlist.begin(); addlist.end() != additer; ++additer){
+				found = false;
+				if(additer->empty()){
+					continue;
+				}
+				for(strlst_t::const_iterator hostiter = iter->second.hostnames.begin(); iter->second.hostnames.end() != hostiter; ++hostiter){
+					if((*hostiter) == (*additer)){
+						found = true;
+						break;
+					}
+				}
+				if(!found){
+					AddUniqueStringToList(*additer, iter->second.hostnames, false);
+					AddUniqueStringToList(*additer, newhostnames, false);
+				}
+			}
+			// add ip address
+			found = false;
+			for(strlst_t::const_iterator ipiter = iter->second.ipaddresses.begin(); iter->second.ipaddresses.end() != ipiter; ++ipiter){
+				if((*ipiter) == target){
+					found = true;
+					break;
+				}
+			}
+			if(!found){
+				AddUniqueStringToList(target, iter->second.ipaddresses, false);
+			}
+			// update timeout
+			iter->second.cached_time = (is_noexp && 0 == iter->second.cached_time) ? 0 : time(NULL);
 
-	return true;
+		}else{
+			// not found, add new cache
+			CHMNDBCACHE	newcache;
+			AddUniqueStringToList(target, newcache.ipaddresses, true);
+			AddUniqueStringListToList(addlist, newcache.hostnames, true);
+			newcache.cached_time = is_noexp ? 0 : time(NULL);
+
+			cachemap[target] = newcache;
+
+			AddUniqueStringListToList(addlist, newhostnames, false);
+		}
+
+		// add hostnames(re-entrant)
+		if(!is_reentrant){
+			strlst_t	addipaddrs;
+			addipaddrs.push_back(target);
+			for(strlst_t::const_iterator hostiter2 = newhostnames.begin(); newhostnames.end() != hostiter2; ++hostiter2){
+				if(!RawAddCache(*hostiter2, addipaddrs, is_noexp, true, true)){
+					result = false;
+				}
+			}
+		}
+	}
+	if(!is_reentrant){
+		fullock::flck_unlock_noshared_mutex(&ChmNetDb::lockval);
+	}
+	return result;
+}
+
+bool ChmNetDb::HostnammeAddCache(const string& hostname, const string& ipaddr, bool is_noexp)
+{
+	strlst_t	ipaddrs;
+	ipaddrs.push_back(ipaddr);
+	return RawAddCache(hostname, ipaddrs, is_noexp, true);
+}
+
+bool ChmNetDb::HostnammeAddCache(const string& hostname, const strlst_t& ipaddrs, bool is_noexp)
+{
+	return RawAddCache(hostname, ipaddrs, is_noexp, true);
+}
+
+bool ChmNetDb::IpAddressAddCache(const string& ipaddr, const string& hostname, bool is_noexp)
+{
+	bool		result = true;
+	strlst_t	hostnames;
+	hostnames.push_back(hostname);
+
+	// if ipaddr is IPv6 with zone index, we set both to cache.
+	if(string::npos != ipaddr.find('%')){
+		string	nozi= ChmNetDb::GetNoZoneIndexIpAddress(ipaddr);
+		result		= RawAddCache(nozi, hostnames, is_noexp, false);
+	}
+	if(!RawAddCache(ipaddr, hostnames, is_noexp, false)){
+		result		= false;
+	}
+	return result;
+}
+
+bool ChmNetDb::IpAddressAddCache(const string& ipaddr, const strlst_t& hostnames, bool is_noexp)
+{
+	bool		result = true;
+
+	// if ipaddr is IPv6 with zone index, we set both to cache.
+	if(string::npos != ipaddr.find('%')){
+		string	nozi= ChmNetDb::GetNoZoneIndexIpAddress(ipaddr);
+		result		= RawAddCache(nozi, hostnames, is_noexp, false);
+	}
+	if(!RawAddCache(ipaddr, hostnames, is_noexp, false)){
+		result		= false;
+	}
+	return result;
 }
 
 bool ChmNetDb::SearchCache(const char* target, CHMNDBCACHE& data)
@@ -379,30 +745,26 @@ bool ChmNetDb::SearchCache(const char* target, CHMNDBCACHE& data)
 		ERR_CHMPRN("Parameter is wrong.");
 		return false;
 	}
-	bool	result = false;
-
 	while(!fullock::flck_trylock_noshared_mutex(&ChmNetDb::lockval));
 
-	string	strtarget(target);
-	if(cachemap.end() != cachemap.find(strtarget)){
-		if(0 != timeout && timeout < (time(NULL) - cachemap[strtarget].cached_time)){
+	string					strtarget(target);
+	bool					result	= false;
+	chmndbmap_t::iterator	iter	= cachemap.find(strtarget);
+	if(cachemap.end() == iter){
+		// if target is IPv6 with zone index, try to check no zone index.
+		if(string::npos != strtarget.find('%')){
+			string	nozi= ChmNetDb::GetNoZoneIndexIpAddress(strtarget);
+			iter		= cachemap.find(nozi);
+		}
+	}
+	if(cachemap.end() != iter){
+		if(0 != timeout && time(NULL) < (iter->second.cached_time + timeout)){
 			MSG_CHMPRN("find cache but it is old, do removing cache.");
-
-			string	tmpipaddress= cachemap[strtarget].ipaddress;
-			string	tmphostname	= cachemap[strtarget].hostname;
-			if(cachemap.end() != cachemap.find(tmpipaddress)){
-				cachemap.erase(tmpipaddress);
-			}
-			if(cachemap.end() != cachemap.find(tmphostname)){
-				cachemap.erase(tmphostname);
-			}
-			if(cachemap.end() != cachemap.find(strtarget)){
-				cachemap.erase(strtarget);
-			}
+			cachemap.erase(iter);
 		}else{
-			data.ipaddress		= cachemap[strtarget].ipaddress;
-			data.hostname		= cachemap[strtarget].hostname;
-			data.cached_time	= cachemap[strtarget].cached_time;
+			AddUniqueStringListToList(iter->second.ipaddresses, data.ipaddresses, true);
+			AddUniqueStringListToList(iter->second.hostnames, data.hostnames, true);
+			data.cached_time	= time(NULL);				// always now, because this value is not used outside.
 			result				= true;
 		}
 	}
@@ -417,41 +779,121 @@ bool ChmNetDb::Search(const char* target, CHMNDBCACHE& data, bool is_cvt_localho
 		ERR_CHMPRN("Parameter is wrong.");
 		return false;
 	}
-	if(SearchCache(target, data)){
-		return true;		// Hit cache
-	}
 
-	string	hostname;
-	string	ipaddress;
-	if(!GetHostAddressInfo(target, hostname, ipaddress)){
-		//MSG_CHMPRN("Could not find hostname or IP address by %s.", target);
-		return false;
+	// search in chache
+	if(!SearchCache(target, data)){
+		// not found in cache
+		if(!GetHostAddressInfo(target, data)){
+			//MSG_CHMPRN("Could not find hostname or IP address by %s.", target);
+			return false;
+		}
 	}
 
 	// If localhost, using global name, ip.
-	if(is_cvt_localhost && (hostname == "localhost" || ipaddress == "127.0.0.1" || ipaddress == "::1")){
-		char	localname[NI_MAXHOST];
-		if(0 != gethostname(localname, sizeof(localname))){
-			MSG_CHMPRN("Could not get localhost name, errno=%d", errno);
-			return false;
-		}
-		// retry
-		if(!GetHostAddressInfo(localname, hostname, ipaddress)){
-			MSG_CHMPRN("Could not find hostname or IP address by %s.", localname);
-			return false;
+	if(is_cvt_localhost){
+		// check localhost(or 127.0.0.1 or ::1) and remove it.
+		if(RemoveLocalhostInCache(data)){
+			// found, then get address info by full local hostname
+			if(!GetHostAddressInfo(fulllocalname.c_str(), data)){
+				MSG_CHMPRN("Could not find full local hostname or IP address by %s.", fulllocalname.c_str());
+			}else{
+				// remove (only) localhost
+				RemoveLocalhostInCache(data);
+			}
 		}
 	}
-	data.ipaddress		= ipaddress;
-	data.hostname		= hostname;
-	data.cached_time	= time(NULL);
+	return true;
+}
 
-	// set cache
-	while(!fullock::flck_trylock_noshared_mutex(&ChmNetDb::lockval));
+// [NOTE]
+// If one FQDN has many address(ex. it specifies in /etc/hosts), this method returns
+// all hostnames and ip addresses.
+//
+bool ChmNetDb::GetHostAddressInfo(const char* target, CHMNDBCACHE& data)
+{
+	// [NOTE]
+	// do not clear data in this method.
 
-	cachemap[ipaddress] = data;
-	cachemap[hostname] = data;
+	struct addrinfo		hints;
+	struct addrinfo*	res_info = NULL;
+	struct addrinfo*	tmpaddrinfo;
+	char				hostname[NI_MAXHOST];
+	char				ipaddr[NI_MAXHOST];
+	int					result;
 
-	fullock::flck_unlock_noshared_mutex(&ChmNetDb::lockval);
+	if(CHMEMPTYSTR(target)){
+		ERR_CHMPRN("Parameter is wrong.");
+		return false;
+	}
+
+	// target -> addrinfo
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_flags		= AI_CANONNAME;
+	hints.ai_family		= AF_UNSPEC;
+	hints.ai_socktype	= SOCK_STREAM;
+	if(0 != getaddrinfo(target, NULL, &hints, &res_info) || !res_info){				// port is NULL
+		return false;
+	}
+
+	// addrinfo(list) -> hostname
+	for(tmpaddrinfo = res_info; tmpaddrinfo; tmpaddrinfo = tmpaddrinfo->ai_next){
+		memset(&hostname, 0, sizeof(hostname));
+		if(0 != (result = getnameinfo(tmpaddrinfo->ai_addr, tmpaddrinfo->ai_addrlen, hostname, sizeof(hostname), NULL, 0, NI_NAMEREQD | NI_NUMERICSERV))){
+			MSG_CHMPRN("Could not get hostname %s, errno=%d.", target, result);
+		}else{
+			// add hostname
+			AddUniqueStringToList(string(hostname), data.hostnames, false);
+
+			// add cache
+			if(0 != (result = getnameinfo(tmpaddrinfo->ai_addr, tmpaddrinfo->ai_addrlen, ipaddr, sizeof(ipaddr), NULL, 0, NI_NUMERICHOST | NI_NUMERICSERV))){
+				HostnammeAddCache(string(hostname), string(ipaddr));
+			}
+		}
+	}
+
+	// addrinfo -> normalized ipaddress
+	for(tmpaddrinfo = res_info; tmpaddrinfo; tmpaddrinfo = tmpaddrinfo->ai_next){
+		memset(&ipaddr, 0, sizeof(ipaddr));
+		if(0 != (result = getnameinfo(tmpaddrinfo->ai_addr, tmpaddrinfo->ai_addrlen, ipaddr, sizeof(ipaddr), NULL, 0, NI_NUMERICHOST | NI_NUMERICSERV))){
+			MSG_CHMPRN("Could not convert normalized ipaddress  %s, errno=%d.", target, result);
+		}else{
+			// add ip address
+			AddUniqueStringToList(string(ipaddr), data.ipaddresses, false);
+
+			// add cache
+			if(0 != (result = getnameinfo(tmpaddrinfo->ai_addr, tmpaddrinfo->ai_addrlen, hostname, sizeof(hostname), NULL, 0, NI_NAMEREQD | NI_NUMERICSERV))){
+				IpAddressAddCache(string(ipaddr), string(hostname));
+			}
+		}
+	}
+	freeaddrinfo(res_info);
+
+	// if short local hostname, adds fully hostname.
+	bool	found = false;
+	for(strlst_t::const_iterator iter1 = data.hostnames.begin(); data.hostnames.end() != iter1; ++iter1){
+		if((*iter1) == fulllocalname){
+			// already has full local hostname
+			found = true;
+			break;
+		}
+	}
+	if(!found){
+		// if hostnames has one of localnames, add full local hostname.
+		for(strlst_t::const_iterator iter2 = data.hostnames.begin(); data.hostnames.end() != iter2; ++iter2){
+			found = false;
+			for(strlst_t::const_iterator iter3 = localnames.begin(); localnames.end() != iter3; ++iter3){
+				if((*iter2) == (*iter3)){
+					found = true;
+					AddUniqueStringToList(fulllocalname, data.hostnames, false);
+					break;
+				}
+			}
+			if(found){
+				break;
+			}
+		}
+	}
+	data.cached_time = time(NULL);
 
 	return true;
 }
@@ -464,24 +906,63 @@ bool ChmNetDb::GetAddrInfo(const char* target, short port, struct addrinfo** ppa
 	}
 	*ppaddrinfo = NULL;
 
+	addrinfolist_t	infolist;
+	if(!GetAddrInfoList(target, port, infolist, is_cvt_localhost) || infolist.empty()){
+		ChmNetDb::FreeAddrInfoList(infolist);
+		return false;
+	}
+	*ppaddrinfo = infolist.front();
+	infolist.pop_front();
+	ChmNetDb::FreeAddrInfoList(infolist);
+
+	return true;
+}
+
+bool ChmNetDb::GetAddrInfoList(const char* target, short port, addrinfolist_t& infolist, bool is_cvt_localhost)
+{
+	if(CHMEMPTYSTR(target)){
+		ERR_CHMPRN("Parameter is wrong.");
+		return false;
+	}
+	ChmNetDb::FreeAddrInfoList(infolist);
+
 	CHMNDBCACHE	data;
 	if(!Search(target, data, is_cvt_localhost)){
 		MSG_CHMPRN("Failed to convert %s to addrinfo structure.", target);
 		return false;
 	}
 
-	struct addrinfo	hints;
-	int				result;
-	string			strPort = to_string(port);
-
+	// get address information
+	string				strPort = to_string(port);
+	struct addrinfo*	paddrinfo;
+	struct addrinfo		hints;
 	memset(&hints, 0, sizeof(hints));
 	hints.ai_flags		= AI_CANONNAME;
 	hints.ai_family		= AF_UNSPEC;
 	hints.ai_socktype	= SOCK_STREAM;
 
-	// addrinfo
-	if(0 != (result = getaddrinfo(data.ipaddress.c_str(), strPort.c_str(), &hints, ppaddrinfo)) || !(*ppaddrinfo)){
-		MSG_CHMPRN("Could not get addrinfo from %s[%d], errno=%d.", target, port, result);
+	// ip addresses
+	int							result;
+	strlst_t::const_iterator	iter;
+	for(iter = data.ipaddresses.begin(); data.ipaddresses.end() != iter; ++iter){
+		paddrinfo = NULL;
+		if(0 != (result = getaddrinfo(iter->c_str(), strPort.c_str(), &hints, &paddrinfo)) || !paddrinfo){
+			MSG_CHMPRN("Could not get addrinfo from %s[%d], errno=%d.", target, port, result);
+		}else{
+			infolist.push_back(paddrinfo);
+		}
+	}
+	// hostnames
+	for(iter = data.hostnames.begin(); data.hostnames.end() != iter; ++iter){
+		paddrinfo = NULL;
+		if(0 != (result = getaddrinfo(iter->c_str(), strPort.c_str(), &hints, &paddrinfo)) || !paddrinfo){
+			MSG_CHMPRN("Could not get addrinfo from %s[%d], errno=%d.", target, port, result);
+		}else{
+			infolist.push_back(paddrinfo);
+		}
+	}
+	if(infolist.empty()){
+		MSG_CHMPRN("Could not get any addrinfo from all ipaddresses and fqdns from %s[%d].", target, port);
 		return false;
 	}
 	return true;
@@ -489,22 +970,78 @@ bool ChmNetDb::GetAddrInfo(const char* target, short port, struct addrinfo** ppa
 
 bool ChmNetDb::GetHostname(const char* target, string& hostname, bool is_cvt_localhost)
 {
+	strlst_t	hostnames;
+	if(!GetHostnameList(target, hostnames, is_cvt_localhost)){
+		return false;
+	}
+	if(hostnames.empty()){
+		MSG_CHMPRN("No hostname is found from %s", target);
+		return false;
+	}
+	hostname = hostnames.front();	// set from first position
+
+	return true;
+}
+
+bool ChmNetDb::GetHostnameList(const char* target, strlst_t& hostnames, bool is_cvt_localhost)
+{
 	if(CHMEMPTYSTR(target)){
 		ERR_CHMPRN("Parameter is wrong.");
 		return false;
 	}
-
 	CHMNDBCACHE	data;
 	if(!Search(target, data, is_cvt_localhost)){
 		//MSG_CHMPRN("Failed to convert %s to addrinfo structure.", target);
 		return false;
 	}
-	hostname = data.hostname;
+	AddUniqueStringListToList(data.hostnames, hostnames, true);
+	AddFullLocalHostname(hostnames);
 
 	return true;
 }
 
+// {NOTE]
+// If the same hostname as localhost is detected, add full local hostname to the beginning.
+// (If it exists in the middle of the list, it moves to the top)
+//
+void ChmNetDb::AddFullLocalHostname(strlst_t& hostnames)
+{
+	bool	found = false;
+	for(strlst_t::iterator iter = hostnames.begin(); hostnames.end() != iter; ){
+		if((*iter) == fulllocalname){
+			iter	= hostnames.erase(iter);
+			found	= true;
+			break;
+		}
+		for(strlst_t::const_iterator liter = localnames.begin(); localnames.end() != liter; ++liter){
+			if((*iter) == (*liter)){
+				found = true;
+				break;
+			}
+		}
+		++iter;
+	}
+	if(found){
+		hostnames.push_front(fulllocalname);
+	}
+}
+
 bool ChmNetDb::GetIpAddressString(const char* target, string& ipaddress, bool is_cvt_localhost)
+{
+	strlst_t	ipaddrs;
+	if(!GetIpAddressStringList(target, ipaddrs, is_cvt_localhost)){
+		return false;
+	}
+	if(ipaddrs.empty()){
+		MSG_CHMPRN("No ip address is found from %s", target);
+		return false;
+	}
+	ipaddress = ipaddrs.front();	// set from first position
+
+	return true;
+}
+
+bool ChmNetDb::GetIpAddressStringList(const char* target, strlst_t& ipaddrs, bool is_cvt_localhost)
 {
 	if(CHMEMPTYSTR(target)){
 		ERR_CHMPRN("Parameter is wrong.");
@@ -516,7 +1053,53 @@ bool ChmNetDb::GetIpAddressString(const char* target, string& ipaddress, bool is
 		MSG_CHMPRN("Failed to convert %s to addrinfo structure.", target);
 		return false;
 	}
-	ipaddress = data.ipaddress;
+	AddUniqueStringListToList(data.ipaddresses, ipaddrs, true);
+	ExpandZoneIndexInList(ipaddrs);
+
+	return true;
+}
+
+// [NOTE]
+// Returns all hostname and IP addresses which are ordered by below.
+// full hostname -> hostanmes -> IP addresses (-> localhost) -> target(hostname)
+//
+bool ChmNetDb::GetAllHostList(const char* target, strlst_t& expandlist, bool is_cvt_localhost)
+{
+	if(CHMEMPTYSTR(target)){
+		ERR_CHMPRN("Parameter is wrong.");
+		return false;
+	}
+
+	if(ChmNetDb::IsLocalhostKeyword(target)){
+		// case localhost
+		AddUniqueStringListToList(localnames, expandlist, false);
+		AddUniqueStringListToList(localaddrs, expandlist, false);
+
+		if(is_cvt_localhost){
+			RemoveLocalhostKeys(expandlist);
+		}
+	}else{
+		strlst_t	tmplist;
+		GetHostnameList(target, tmplist, true);						// without localhost
+		AddUniqueStringListToList(tmplist, expandlist, true);		// first adding, then clear it.
+
+		tmplist.clear();
+		GetIpAddressStringList(target, tmplist, true);				// without localhost
+		AddUniqueStringListToList(tmplist, expandlist, false);
+
+		if(!is_cvt_localhost){
+			tmplist.clear();
+			GetHostnameList(target, tmplist, false);				// with localhost
+			AddUniqueStringListToList(tmplist, expandlist, false);
+
+			tmplist.clear();
+			GetIpAddressStringList(target, tmplist, false);			// with localhost
+			AddUniqueStringListToList(tmplist, expandlist, false);
+		}
+		AddUniqueStringToList(string(target), expandlist, false);	// last
+	}
+	// cut zone index
+	RemoveZoneIndexInList(expandlist);
 
 	return true;
 }

--- a/lib/chmnetdb.h
+++ b/lib/chmnetdb.h
@@ -33,12 +33,15 @@
 // Structure
 //---------------------------------------------------------
 typedef struct chm_netdb_cache{
-	std::string		ipaddress;
-	std::string		hostname;
-	time_t			cached_time;
+	strlst_t		ipaddresses;
+	strlst_t		hostnames;
+	time_t			cached_time;							// set 0 if not cashed out.
+
+	chm_netdb_cache() : cached_time(0) {}
 }CHMNDBCACHE, *PCHMNDBCACHE;
 
 typedef std::map<std::string, CHMNDBCACHE>	chmndbmap_t;	// Key is ipaddress or hostname
+typedef std::list<struct addrinfo*>			addrinfolist_t;
 
 //---------------------------------------------------------
 // Class ChmNetDb
@@ -52,18 +55,27 @@ class ChmNetDb
 		chmndbmap_t			cachemap;
 		time_t				timeout;			// 0 means no timeout
 		std::string			fulllocalname;		// local hostname from uname(gethostname), this is Full FQDN.
-		std::string			localname;			// local hostname from getnameinfo, sometimes this name is without domain name if set in /etc/hosts.
+		strlst_t			localaddrs;			// local ip addresses
+		strlst_t			localnames;			// local hostname from getnameinfo, sometimes this name is without domain name if set in /etc/hosts.
 
 	protected:
 		ChmNetDb();
 		virtual ~ChmNetDb();
 
-		bool InitializeLocalHostName(void);
+		bool InitializeLocalHostInfo(void);
+		bool InitializeLocalHostIpAddresses(void);
+		bool InitializeLocalHostnames(void);
 		bool ClearEx(void);
 		bool CacheOutEx(void);
-		bool GetHostAddressInfo(const char* target, std::string& strhostname, std::string& stripaddress);
+		bool RawAddCache(const std::string& target, const strlst_t& addlist, bool is_noexp, bool is_hostname, bool is_reentrant = false);
+		bool HostnammeAddCache(const std::string& hostname, const std::string& ipaddr, bool is_noexp = false);
+		bool HostnammeAddCache(const std::string& hostname, const strlst_t& ipaddrs, bool is_noexp = false);
+		bool IpAddressAddCache(const std::string& ipaddr, const std::string& hostname, bool is_noexp = false);
+		bool IpAddressAddCache(const std::string& ipaddr, const strlst_t& hostnames, bool is_noexp = false);
 		bool SearchCache(const char* target, CHMNDBCACHE& data);
 		bool Search(const char* target, CHMNDBCACHE& data, bool is_cvt_localhost);
+		bool GetHostAddressInfo(const char* target, CHMNDBCACHE& data);
+		void AddFullLocalHostname(strlst_t& hostnames);
 
 	public:
 		static ChmNetDb* Get(void);
@@ -71,15 +83,24 @@ class ChmNetDb
 		static bool Clear(void);
 		static bool CacheOut(void);
 		static bool GetLocalHostname(std::string& hostname);
+		static bool GetLocalHostnameList(strlst_t& hostnames);
+		static bool GetLocalHostList(strlst_t& hostinfo, bool remove_localhost = false);
 		static bool GetAnyAddrInfo(short port, struct addrinfo** ppaddrinfo, bool is_inetv6);
 		static bool CvtAddrInfoToIpAddress(const struct sockaddr_storage* info, socklen_t infolen, std::string& stripaddress);
 		static bool CvtSockToLocalPort(int sock, short& port);
 		static bool CvtSockToPeerPort(int sock, short& port);
 		static bool CvtV4MappedAddrInfo(struct sockaddr_storage* info, socklen_t& addrlen);
+		static void FreeAddrInfoList(addrinfolist_t& infolist);
+		static std::string GetNoZoneIndexIpAddress(const std::string& ipaddr);
+		static bool IsLocalhostKeyword(const char* host);
 
 		bool GetAddrInfo(const char* target, short port, struct addrinfo** ppaddrinfo, bool is_cvt_localhost);	// Must freeaddrinfo for *ppaddrinfo
+		bool GetAddrInfoList(const char* target, short port, addrinfolist_t& infolist, bool is_cvt_localhost);	// Must FreeAddrInfoList for clear
 		bool GetHostname(const char* target, std::string& hostname, bool is_cvt_localhost);
+		bool GetHostnameList(const char* target, strlst_t& hostnames, bool is_cvt_localhost);
 		bool GetIpAddressString(const char* target, std::string& ipaddress, bool is_cvt_localhost);
+		bool GetIpAddressStringList(const char* target, strlst_t& ipaddrs, bool is_cvt_localhost);
+		bool GetAllHostList(const char* target, strlst_t& expandlist, bool is_cvt_localhost);
 };
 
 #endif	// CHMNETDB_H

--- a/lib/chmpx.cc
+++ b/lib/chmpx.cc
@@ -182,7 +182,7 @@ bool chmpx_svr_send_kvp_ex(chmpx_h handle, const PCHMKVP pkvp, bool is_routing, 
 		return false;
 	}
 
-	ChmKVPair		kvpair(pkvp);
+	ChmKVPair		kvpair(pkvp, false);
 	unsigned char*	pbody;
 	size_t			length = 0L;
 	if(NULL == (pbody = kvpair.Put(length))){
@@ -316,7 +316,7 @@ bool chmpx_msg_send_kvp(chmpx_h handle, msgid_t msgid, const PCHMKVP pkvp, long*
 		ERR_CHMPRN("Invalid chmpx handle.");
 		return false;
 	}
-	ChmKVPair		kvpair(pkvp);
+	ChmKVPair		kvpair(pkvp, false);
 	unsigned char*	pbody;
 	size_t			length = 0L;
 	if(NULL == (pbody = kvpair.Put(length))){
@@ -425,7 +425,7 @@ bool chmpx_msg_reply_kvp(chmpx_h handle, chmpx_pkt_h pckthandle, const PCHMKVP p
 		return false;
 	}
 
-	ChmKVPair		kvpair(pkvp);
+	ChmKVPair		kvpair(pkvp, false);
 	unsigned char*	pbody;
 	size_t			length = 0L;
 	if(NULL == (pbody = kvpair.Put(length))){

--- a/lib/chmregex.h
+++ b/lib/chmregex.h
@@ -27,7 +27,7 @@
 // Utilities
 //---------------------------------------------------------
 bool ExpandSimpleRegxHostname(const char* hostname, strlst_t& expand_lst, bool is_cvt_localhost, bool is_cvt_fqdn = true, bool is_strict = false);
-bool IsInHostnameList(const char* hostname, strlst_t& hostname_lst, std::string& matchhostname);
+bool IsInHostnameList(const char* hostname, strlst_t& hostname_lst, std::string& matchhostname, bool is_cvt_localhost = false);
 bool IsMatchHostname(const char* hostname, strlst_t& regex_lst, std::string& matchhostname);
 
 #endif	// CHMREGEX_H


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
Server node settings can now be specified by IP address instead of FQDN(hostname).
Hosts with IP addresses that are not registered in DNS can be registered as server nodes.
This PR has made corrections related to this.

Also, errors and warnings output by cppcheck are corrected.

