### PR TITLE
Update netdb

### DIFF
--- a/lib/chmcntrl.cc
+++ b/lib/chmcntrl.cc
@@ -192,8 +192,8 @@ bool ChmCntrl::Initialize(const char* cfgfile, CHMCNTRLTYPE type, bool is_auto_r
 		Clean(bup_cfg.empty());
 		return false;
 	}
-	const CHMCFGINFO*	pchmcfg = pConfObj->GetConfiguration();
-	if(!pchmcfg){
+	CHMCFGINFO	chmcfg;
+	if(!pConfObj->GetConfiguration(chmcfg)){
 		ERR_CHMPRN("Failed to load configuration from %s", cfgfile);
 		Clean(bup_cfg.empty());
 		return false;
@@ -210,7 +210,7 @@ bool ChmCntrl::Initialize(const char* cfgfile, CHMCNTRLTYPE type, bool is_auto_r
 		// If client process joining on slave chmpx, MQPERATTACH and MAXQPERCLIENTMQ should be "1".
 		// But you can set not "1", so put a message here.
 		//
-		if(1 != pchmcfg->mqcnt_per_attach || 1 != pchmcfg->max_q_per_clientmq){
+		if(1 != chmcfg.mqcnt_per_attach || 1 != chmcfg.max_q_per_clientmq){
 			MSG_CHMPRN("Client process on slave chmpx must be 1 for MQPERATTACH and MAXQPERCLIENTMQ in configuration.");
 		}
 	}

--- a/lib/chmconf.h
+++ b/lib/chmconf.h
@@ -54,7 +54,33 @@ typedef struct chm_node_cfg_info{
 	std::string		slave_cert;
 	std::string		slave_prikey;
 
-	chm_node_cfg_info() : name(""), port(0), ctlport(0), is_ssl(false), verify_peer(false), is_ca_file(false), capath(""), server_cert(""), server_prikey(""), slave_cert(""), slave_prikey("") {}
+	chm_node_cfg_info() :
+		name(""),
+		port(0),
+		ctlport(0),
+		is_ssl(false),
+		verify_peer(false),
+		is_ca_file(false),
+		capath(""),
+		server_cert(""),
+		server_prikey(""),
+		slave_cert(""),
+		slave_prikey("")
+	{}
+
+	chm_node_cfg_info(const struct chm_node_cfg_info& other) :
+		name(other.name),
+		port(other.port),
+		ctlport(other.ctlport),
+		is_ssl(other.is_ssl),
+		verify_peer(other.verify_peer),
+		is_ca_file(other.is_ca_file),
+		capath(other.capath),
+		server_cert(other.server_cert),
+		server_prikey(other.server_prikey),
+		slave_cert(other.slave_cert),
+		slave_prikey(other.slave_prikey)
+	{}
 
 	bool compare(const struct chm_node_cfg_info& other) const
 	{
@@ -73,6 +99,22 @@ typedef struct chm_node_cfg_info{
 			return true;
 		}
 		return false;
+	}
+	struct chm_node_cfg_info& operator=(const struct chm_node_cfg_info& other)
+	{
+		name			= other.name;
+		port			= other.port;
+		ctlport			= other.ctlport;
+		is_ssl			= other.is_ssl;
+		verify_peer		= other.verify_peer;
+		is_ca_file		= other.is_ca_file;
+		capath			= other.capath;
+		server_cert		= other.server_cert;
+		server_prikey	= other.server_prikey;
+		slave_cert		= other.slave_cert;
+		slave_prikey	= other.slave_prikey;
+
+		return *this;
 	}
 	bool operator==(const struct chm_node_cfg_info& other) const
 	{
@@ -158,13 +200,86 @@ typedef struct chm_cfg_info{
 	chmnode_cfginfos_t	slaves;
 
 	chm_cfg_info() :
-		groupname(""), revision(UNINITIALIZE_REVISION), is_server_mode(false), is_random_mode(false), self_ctlport(CHM_INVALID_PORT),
-		max_chmpx_count(0L), replica_count(0L), max_server_mq_cnt(0L), max_client_mq_cnt(0L), mqcnt_per_attach(0L), max_q_per_servermq(0L),
-		max_q_per_clientmq(0L), max_mq_per_client(0L), max_histlog_count(0L), retrycnt(-1), mq_retrycnt(-1), mq_ack(true), timeout_wait_socket(-1),
-		timeout_wait_connect(-1), timeout_wait_mq(-1), is_auto_merge(false), is_do_merge(false), timeout_merge(0), sock_thread_cnt(0), mq_thread_cnt(0),
-		max_sock_pool(1), sock_pool_timeout(0), k2h_fullmap(true), k2h_mask_bitcnt(K2HShm::DEFAULT_MASK_BITCOUNT), k2h_cmask_bitcnt(K2HShm::DEFAULT_COLLISION_MASK_BITCOUNT),
-		k2h_max_element(K2HShm::DEFAULT_MAX_ELEMENT_CNT), date(0L), ssl_min_ver(CHM_SSLTLS_VER_DEFAULT), nssdb_dir("")
+		groupname(""),
+		revision(UNINITIALIZE_REVISION),
+		is_server_mode(false),
+		is_random_mode(false),
+		self_ctlport(CHM_INVALID_PORT),
+		max_chmpx_count(0L),
+		replica_count(0L),
+		max_server_mq_cnt(0L),
+		max_client_mq_cnt(0L),
+		mqcnt_per_attach(0L),
+		max_q_per_servermq(0L),
+		max_q_per_clientmq(0L),
+		max_mq_per_client(0L),
+		max_histlog_count(0L),
+		retrycnt(-1),
+		mq_retrycnt(-1),
+		mq_ack(true),
+		timeout_wait_socket(-1),
+		timeout_wait_connect(-1),
+		timeout_wait_mq(-1),
+		is_auto_merge(false),
+		is_do_merge(false),
+		timeout_merge(0),
+		sock_thread_cnt(0),
+		mq_thread_cnt(0),
+		max_sock_pool(1),
+		sock_pool_timeout(0),
+		k2h_fullmap(true),
+		k2h_mask_bitcnt(K2HShm::DEFAULT_MASK_BITCOUNT),
+		k2h_cmask_bitcnt(K2HShm::DEFAULT_COLLISION_MASK_BITCOUNT),
+		k2h_max_element(K2HShm::DEFAULT_MAX_ELEMENT_CNT),
+		date(0L),
+		ssl_min_ver(CHM_SSLTLS_VER_DEFAULT),
+		nssdb_dir("")
 	{}
+
+	chm_cfg_info(const struct chm_cfg_info& other) :
+		groupname(other.groupname),
+		revision(other.revision),
+		is_server_mode(other.is_server_mode),
+		is_random_mode(other.is_random_mode),
+		self_ctlport(other.self_ctlport),
+		max_chmpx_count(other.max_chmpx_count),
+		replica_count(other.replica_count),
+		max_server_mq_cnt(other.max_server_mq_cnt),
+		max_client_mq_cnt(other.max_client_mq_cnt),
+		mqcnt_per_attach(other.mqcnt_per_attach),
+		max_q_per_servermq(other.max_q_per_servermq),
+		max_q_per_clientmq(other.max_q_per_clientmq),
+		max_mq_per_client(other.max_mq_per_client),
+		max_histlog_count(other.max_histlog_count),
+		retrycnt(other.retrycnt),
+		mq_retrycnt(other.mq_retrycnt),
+		mq_ack(other.mq_ack),
+		timeout_wait_socket(other.timeout_wait_socket),
+		timeout_wait_connect(other.timeout_wait_connect),
+		timeout_wait_mq(other.timeout_wait_mq),
+		is_auto_merge(other.is_auto_merge),
+		is_do_merge(other.is_do_merge),
+		timeout_merge(other.timeout_merge),
+		sock_thread_cnt(other.sock_thread_cnt),
+		mq_thread_cnt(other.mq_thread_cnt),
+		max_sock_pool(other.max_sock_pool),
+		sock_pool_timeout(other.sock_pool_timeout),
+		k2h_fullmap(other.k2h_fullmap),
+		k2h_mask_bitcnt(other.k2h_mask_bitcnt),
+		k2h_cmask_bitcnt(other.k2h_cmask_bitcnt),
+		k2h_max_element(other.k2h_max_element),
+		date(other.date),
+		ssl_min_ver(other.ssl_min_ver),
+		nssdb_dir(other.nssdb_dir)
+	{
+		chmnode_cfginfos_t::const_iterator	iter;
+		for(iter = other.servers.begin(); other.servers.end() != iter; ++iter){
+			servers.push_back(*iter);
+		}
+		for(iter = other.slaves.begin(); other.slaves.end() != iter; ++iter){
+			slaves.push_back(*iter);
+		}
+	}
 
 	bool compare(const struct chm_cfg_info& other) const
 	{
@@ -208,6 +323,52 @@ typedef struct chm_cfg_info{
 			return true;
 		}
 		return false;
+	}
+	struct chm_cfg_info& operator=(const struct chm_cfg_info& other)
+	{
+		groupname				= other.groupname;
+		revision				= other.revision;
+		is_server_mode			= other.is_server_mode;
+		is_random_mode			= other.is_random_mode;
+		self_ctlport			= other.self_ctlport;
+		max_chmpx_count			= other.max_chmpx_count;
+		replica_count			= other.replica_count;
+		max_server_mq_cnt		= other.max_server_mq_cnt;
+		max_client_mq_cnt		= other.max_client_mq_cnt;
+		mqcnt_per_attach		= other.mqcnt_per_attach;
+		max_q_per_servermq		= other.max_q_per_servermq;
+		max_q_per_clientmq		= other.max_q_per_clientmq;
+		max_mq_per_client		= other.max_mq_per_client;
+		max_histlog_count		= other.max_histlog_count;
+		retrycnt				= other.retrycnt;
+		mq_retrycnt				= other.mq_retrycnt;
+		mq_ack					= other.mq_ack;
+		timeout_wait_socket		= other.timeout_wait_socket;
+		timeout_wait_connect	= other.timeout_wait_connect;
+		timeout_wait_mq			= other.timeout_wait_mq;
+		is_auto_merge			= other.is_auto_merge;
+		is_do_merge				= other.is_do_merge;
+		timeout_merge			= other.timeout_merge;
+		sock_thread_cnt			= other.sock_thread_cnt;
+		mq_thread_cnt			= other.mq_thread_cnt;
+		max_sock_pool			= other.max_sock_pool;
+		sock_pool_timeout		= other.sock_pool_timeout;
+		k2h_fullmap				= other.k2h_fullmap;
+		k2h_mask_bitcnt			= other.k2h_mask_bitcnt;
+		k2h_cmask_bitcnt		= other.k2h_cmask_bitcnt;
+		k2h_max_element			= other.k2h_max_element;
+		date					= other.date;
+		ssl_min_ver				= other.ssl_min_ver;
+		nssdb_dir				= other.nssdb_dir;
+
+		chmnode_cfginfos_t::const_iterator	iter;
+		for(iter = other.servers.begin(); other.servers.end() != iter; ++iter){
+			servers.push_back(*iter);
+		}
+		for(iter = other.slaves.begin(); other.slaves.end() != iter; ++iter){
+			slaves.push_back(*iter);
+		}
+		return *this;
 	}
 	bool operator==(const struct chm_cfg_info& other) const
 	{
@@ -264,6 +425,8 @@ class CHMConf : public ChmEventBase
 		};
 
 	protected:
+		static int			lockval;			// like mutex
+
 		std::string			cfgfile;
 		std::string			strjson;
 		short				ctlport_param;
@@ -277,6 +440,7 @@ class CHMConf : public ChmEventBase
 
 		virtual bool LoadConfiguration(CHMCFGINFO& chmcfginfo) const = 0;
 
+		const CHMCFGINFO* GetConfiguration(bool is_check_update = false);		// thread unsafe
 		bool GetServerInfo(const char* hostname, short ctlport, CHMNODE_CFGINFO& svrnodeinfo, bool is_check_update = false);
 		bool GetSelfServerInfo(CHMNODE_CFGINFO& svrnodeinfo, bool is_check_update = false);
 		bool GetSlaveInfo(const char* hostname, short ctlport, CHMNODE_CFGINFO& slvnodeinfo, bool is_check_update = false);
@@ -307,7 +471,7 @@ class CHMConf : public ChmEventBase
 
 		bool CheckConfFile(void) const;
 		bool CheckUpdate(void);
-		const CHMCFGINFO* GetConfiguration(bool is_check_update = false);
+		bool GetConfiguration(CHMCFGINFO& config, bool is_check_update = false);
 
 		bool GetNodeInfo(const char* hostname, short ctlport, CHMNODE_CFGINFO& nodeinfo, bool is_only_server, bool is_check_update = false);
 		bool GetSelfNodeInfo(CHMNODE_CFGINFO& nodeinfo, bool is_check_update = false);

--- a/lib/chmeventsock.cc
+++ b/lib/chmeventsock.cc
@@ -5074,7 +5074,9 @@ bool ChmEventSock::Processing(int sock, const char* pCommand)
 				for(string strTmp = ""; !cmdarray.empty(); cmdarray.pop_front()){
 					strTmp = cmdarray.front();
 
-					if(string::npos == strTmp.find(CTL_COMMAND_TRACE_VIEW_DIR)){
+					// cppcheck-suppress unmatchedSuppression
+					// cppcheck-suppress stlIfStrFind
+					if(0 == strTmp.find(CTL_COMMAND_TRACE_VIEW_DIR)){
 						strTmp = strTmp.substr(strlen(CTL_COMMAND_TRACE_VIEW_DIR));
 
 						if(0 == strcasecmp(strTmp.c_str(), CTL_COMMAND_TRACE_VIEW_IN)){
@@ -5088,7 +5090,9 @@ bool ChmEventSock::Processing(int sock, const char* pCommand)
 							isError	= true;
 							break;
 						}
-					}else if(string::npos == strTmp.find(CTL_COMMAND_TRACE_VIEW_DEV)){
+					// cppcheck-suppress unmatchedSuppression
+					// cppcheck-suppress stlIfStrFind
+					}else if(0 == strTmp.find(CTL_COMMAND_TRACE_VIEW_DEV)){
 						strTmp = strTmp.substr(strlen(CTL_COMMAND_TRACE_VIEW_DEV));
 
 						if(0 == strcasecmp(strTmp.c_str(), CTL_COMMAND_TRACE_VIEW_SOCK)){

--- a/lib/chmeventsock.cc
+++ b/lib/chmeventsock.cc
@@ -3920,6 +3920,11 @@ bool ChmEventSock::Accept(int sock)
 	MSG_CHMPRN("Accept new socket(%d)", newsock);
 	fullock::flck_unlock_noshared_mutex(&sockfd_lockval);			// UNLOCK
 
+	// Convert IPv4-mapped IPv6 addresses to plain IPv4.
+	if(!ChmNetDb::CvtV4MappedAddrInfo(&from, fromlen)){
+		ERR_CHMPRN("Something error occured during converting IPv4-mapped IPv6 addresses to plain IPv4, but continue...");
+	}
+
 	// get hostname for accessing control
 	string	stripaddress;
 	string	strhostname;
@@ -3931,6 +3936,7 @@ bool ChmEventSock::Accept(int sock)
 	if(!ChmNetDb::Get()->GetHostname(stripaddress.c_str(), strhostname, true)){
 		MSG_CHMPRN("Could not get hostname(FQDN) from %s, then ip address is instead of hostname.", stripaddress.c_str());
 		strhostname = ChmNetDb::GetNoZoneIndexIpAddress(stripaddress);
+		strhostname = ChmNetDb::CvtIPv4MappedIPv6Address(strhostname);
 	}
 
 	// add tempolary accepting socket mapping.(before adding epoll for multi threading)
@@ -4056,6 +4062,7 @@ bool ChmEventSock::AcceptCtlport(int ctlsock)
 	if(!ChmNetDb::Get()->GetHostname(stripaddress.c_str(), strhostname, true)){
 		MSG_CHMPRN("Could not get hostname(FQDN) from %s, then ip address is instead of hostname.", stripaddress.c_str());
 		strhostname = ChmNetDb::GetNoZoneIndexIpAddress(stripaddress);
+		strhostname = ChmNetDb::CvtIPv4MappedIPv6Address(strhostname);
 	}
 
 	// check ACL

--- a/lib/chmimdata.cc
+++ b/lib/chmimdata.cc
@@ -321,15 +321,15 @@ bool ChmIMData::InitializeK2hash(void)
 		return false;
 	}
 
-	const CHMCFGINFO*	pchmcfg = pConfObj->GetConfiguration();
-	if(!pchmcfg){
-		ERR_CHMPRN("Could not get configuration information structure pointer.");
+	CHMCFGINFO	chmcfg;
+	if(!pConfObj->GetConfiguration(chmcfg)){
+		ERR_CHMPRN("Could not get configuration information structure.");
 		return false;
 	}
 
 	string	k2hfilepath;
-	if(!ChmIMData::MakeK2hashFilePath(pchmcfg->groupname.c_str(), pchmcfg->self_ctlport, k2hfilepath)){
-		ERR_CHMPRN("Failed to make k2hash file path from groupname(%s).", pchmcfg->groupname.c_str());
+	if(!ChmIMData::MakeK2hashFilePath(chmcfg.groupname.c_str(), chmcfg.self_ctlport, k2hfilepath)){
+		ERR_CHMPRN("Failed to make k2hash file path from groupname(%s).", chmcfg.groupname.c_str());
 		return false;
 	}
 	if(is_file_exist(k2hfilepath.c_str())){
@@ -342,7 +342,7 @@ bool ChmIMData::InitializeK2hash(void)
 
 	// init
 	pK2hash = new K2HShm();
-	if(!pK2hash->Create(k2hfilepath.c_str(), pchmcfg->k2h_fullmap, pchmcfg->k2h_mask_bitcnt, pchmcfg->k2h_cmask_bitcnt, pchmcfg->k2h_max_element, ChmIMData::SYSPAGE_SIZE)){
+	if(!pK2hash->Create(k2hfilepath.c_str(), chmcfg.k2h_fullmap, chmcfg.k2h_mask_bitcnt, chmcfg.k2h_cmask_bitcnt, chmcfg.k2h_max_element, ChmIMData::SYSPAGE_SIZE)){
 		ERR_CHMPRN("Failed to create new k2hash file(%s)", k2hfilepath.c_str());
 		CHM_Delete(pK2hash);
 		return false;
@@ -365,15 +365,15 @@ bool ChmIMData::AttachK2hash(void)
 		return false;
 	}
 
-	const CHMCFGINFO*	pchmcfg = pConfObj->GetConfiguration();
-	if(!pchmcfg){
-		ERR_CHMPRN("Could not get configuration information structure pointer.");
+	CHMCFGINFO	chmcfg;
+	if(!pConfObj->GetConfiguration(chmcfg)){
+		ERR_CHMPRN("Could not get configuration information structure.");
 		return false;
 	}
 
 	string	k2hfilepath;
-	if(!ChmIMData::MakeK2hashFilePath(pchmcfg->groupname.c_str(), pchmcfg->self_ctlport, k2hfilepath)){
-		ERR_CHMPRN("Failed to make k2hash file path from groupname(%s).", pchmcfg->groupname.c_str());
+	if(!ChmIMData::MakeK2hashFilePath(chmcfg.groupname.c_str(), chmcfg.self_ctlport, k2hfilepath)){
+		ERR_CHMPRN("Failed to make k2hash file path from groupname(%s).", chmcfg.groupname.c_str());
 		return false;
 	}
 
@@ -384,7 +384,7 @@ bool ChmIMData::AttachK2hash(void)
 
 	// init
 	pK2hash = new K2HShm();
-	if(!pK2hash->Attach(k2hfilepath.c_str(), false, false, false, pchmcfg->k2h_fullmap, pchmcfg->k2h_mask_bitcnt, pchmcfg->k2h_cmask_bitcnt, pchmcfg->k2h_max_element, ChmIMData::SYSPAGE_SIZE)){
+	if(!pK2hash->Attach(k2hfilepath.c_str(), false, false, false, chmcfg.k2h_fullmap, chmcfg.k2h_mask_bitcnt, chmcfg.k2h_cmask_bitcnt, chmcfg.k2h_max_element, ChmIMData::SYSPAGE_SIZE)){
 		ERR_CHMPRN("Failed to attach k2hash file(%s)", k2hfilepath.c_str());
 		CHM_Delete(pK2hash);
 		return false;
@@ -509,9 +509,9 @@ bool ChmIMData::InitializeShm(void)
 		return false;
 	}
 
-	const CHMCFGINFO*	pchmcfg = pConfObj->GetConfiguration();
-	if(!pchmcfg){
-		ERR_CHMPRN("Could not get configuration information structure pointer.");
+	CHMCFGINFO	chmcfg;
+	if(!pConfObj->GetConfiguration(chmcfg)){
+		ERR_CHMPRN("Could not get configuration information structure.");
 		return false;
 	}
 
@@ -519,9 +519,9 @@ bool ChmIMData::InitializeShm(void)
 	//
 	// If chmpx process is mq receiver for all mq sender(client processes), mq size should be max mq count.
 	//
-	long	maxmsg = pchmcfg->max_server_mq_cnt + pchmcfg->max_client_mq_cnt;
+	long	maxmsg = chmcfg.max_server_mq_cnt + chmcfg.max_client_mq_cnt;
 	if(!ChmEventMq::InitializeMaxMqSystemSize(maxmsg)){
-		ERR_CHMPRN("Could not get mq size = %ld for chmpx process.", pchmcfg->max_client_mq_cnt);
+		ERR_CHMPRN("Could not get mq size = %ld for chmpx process.", chmcfg.max_client_mq_cnt);
 		return false;
 	}
 
@@ -531,21 +531,21 @@ bool ChmIMData::InitializeShm(void)
 		return false;
 	}
 
-	return InitializeShmEx(pchmcfg, &self);
+	return InitializeShmEx(chmcfg, &self);
 }
 
-bool ChmIMData::InitializeShmEx(const CHMCFGINFO* pchmcfg, const CHMNODE_CFGINFO* pself)
+bool ChmIMData::InitializeShmEx(const CHMCFGINFO& chmcfg, const CHMNODE_CFGINFO* pself)
 {
-	if(	!pchmcfg || MAX_GROUP_LENGTH <= pchmcfg->groupname.length() || MAX_CHMPX_COUNT < pchmcfg->max_chmpx_count || 
-		MAX_SERVER_MQ_CNT < pchmcfg->max_server_mq_cnt || MAX_CLIENT_MQ_CNT < pchmcfg->max_client_mq_cnt || 
-		MAX_MQ_PER_CLIENT < pchmcfg->max_mq_per_client || MAX_HISTLOG_COUNT < pchmcfg->max_histlog_count )
+	if(	MAX_GROUP_LENGTH <= chmcfg.groupname.length() || MAX_CHMPX_COUNT < chmcfg.max_chmpx_count || 
+		MAX_SERVER_MQ_CNT < chmcfg.max_server_mq_cnt || MAX_CLIENT_MQ_CNT < chmcfg.max_client_mq_cnt || 
+		MAX_MQ_PER_CLIENT < chmcfg.max_mq_per_client || MAX_HISTLOG_COUNT < chmcfg.max_histlog_count )
 	{
 		ERR_CHMPRN("Configuration information are wrong.");
 		return false;
 	}
 	string	shmpath;
-	if(!ChmIMData::MakeShmFilePath(pchmcfg->groupname.c_str(), pchmcfg->self_ctlport, shmpath)){
-		ERR_CHMPRN("Failed to make chmshm file path from groupname(%s).", pchmcfg->groupname.c_str());
+	if(!ChmIMData::MakeShmFilePath(chmcfg.groupname.c_str(), chmcfg.self_ctlport, shmpath)){
+		ERR_CHMPRN("Failed to make chmshm file path from groupname(%s).", chmcfg.groupname.c_str());
 		return false;
 	}
 
@@ -567,12 +567,12 @@ bool ChmIMData::InitializeShmEx(const CHMCFGINFO* pchmcfg, const CHMNODE_CFGINFO
 
 	// file total size
 	size_t	total_shmsize =	sizeof(CHMSHM) + 																						// CHMSHM (this structure is alignmented)
-							sizeof(CHMPXLIST) * pchmcfg->max_chmpx_count + 															// CHMPX Area
-							sizeof(PCHMPX) * pchmcfg->max_chmpx_count * 2 +															// PCHMPX array Area
-							sizeof(MQMSGHEADLIST) * (pchmcfg->max_server_mq_cnt + pchmcfg->max_client_mq_cnt) + 					// MQUEUE Area
-							sizeof(CLTPROCLIST) * MAX_CLTPROCLIST_COUNT(pchmcfg->max_client_mq_cnt, pchmcfg->mqcnt_per_attach) +	// CLTPROCLIST Area
-							sizeof(CHMLOGRAW) * pchmcfg->max_histlog_count +														// LOG Area
-							sizeof(CHMSOCKLIST) * pchmcfg->max_chmpx_count * pchmcfg->max_sock_pool * 2;							// SOCK array Area([NOTICE] twice for margin)
+							sizeof(CHMPXLIST) * chmcfg.max_chmpx_count + 															// CHMPX Area
+							sizeof(PCHMPX) * chmcfg.max_chmpx_count * 2 +															// PCHMPX array Area
+							sizeof(MQMSGHEADLIST) * (chmcfg.max_server_mq_cnt + chmcfg.max_client_mq_cnt) + 						// MQUEUE Area
+							sizeof(CLTPROCLIST) * MAX_CLTPROCLIST_COUNT(chmcfg.max_client_mq_cnt, chmcfg.mqcnt_per_attach) +		// CLTPROCLIST Area
+							sizeof(CHMLOGRAW) * chmcfg.max_histlog_count +															// LOG Area
+							sizeof(CHMSOCKLIST) * chmcfg.max_chmpx_count * chmcfg.max_sock_pool * 2;								// SOCK array Area([NOTICE] twice for margin)
 
 	// truncate with filling zero
 	if(!truncate_filling_zero(fd, total_shmsize, ChmIMData::SYSPAGE_SIZE)){
@@ -594,34 +594,34 @@ bool ChmIMData::InitializeShmEx(const CHMCFGINFO* pchmcfg, const CHMNODE_CFGINFO
 	{
 		PCHMPXLIST		rel_chmpxarea			= reinterpret_cast<PCHMPXLIST>(		sizeof(CHMSHM));
 		PCHMPX*			rel_pchmpxarrarea		= reinterpret_cast<PCHMPX*>(		sizeof(CHMSHM) +
-																					sizeof(CHMPXLIST) * pchmcfg->max_chmpx_count);
+																					sizeof(CHMPXLIST) * chmcfg.max_chmpx_count);
 		PMQMSGHEADLIST	rel_chmpxmsgarea		= reinterpret_cast<PMQMSGHEADLIST>(	sizeof(CHMSHM) +
-																					sizeof(CHMPXLIST) * pchmcfg->max_chmpx_count +
-																					sizeof(PCHMPX) * pchmcfg->max_chmpx_count * 2);
+																					sizeof(CHMPXLIST) * chmcfg.max_chmpx_count +
+																					sizeof(PCHMPX) * chmcfg.max_chmpx_count * 2);
 		PCLTPROCLIST	rel_chmpxpidarea		= reinterpret_cast<PCLTPROCLIST>(	sizeof(CHMSHM) +
-																					sizeof(CHMPXLIST) * pchmcfg->max_chmpx_count +
-																					sizeof(PCHMPX) * pchmcfg->max_chmpx_count * 2 +
-																					sizeof(MQMSGHEADLIST) * (pchmcfg->max_server_mq_cnt + pchmcfg->max_client_mq_cnt));
+																					sizeof(CHMPXLIST) * chmcfg.max_chmpx_count +
+																					sizeof(PCHMPX) * chmcfg.max_chmpx_count * 2 +
+																					sizeof(MQMSGHEADLIST) * (chmcfg.max_server_mq_cnt + chmcfg.max_client_mq_cnt));
 		PCHMLOGRAW		rel_lograwarea			= reinterpret_cast<PCHMLOGRAW>(		sizeof(CHMSHM) +
-																					sizeof(CHMPXLIST) * pchmcfg->max_chmpx_count +
-																					sizeof(PCHMPX) * pchmcfg->max_chmpx_count * 2 +
-																					sizeof(MQMSGHEADLIST) * (pchmcfg->max_server_mq_cnt + pchmcfg->max_client_mq_cnt) +
-																					sizeof(CLTPROCLIST) * MAX_CLTPROCLIST_COUNT(pchmcfg->max_client_mq_cnt, pchmcfg->mqcnt_per_attach));
+																					sizeof(CHMPXLIST) * chmcfg.max_chmpx_count +
+																					sizeof(PCHMPX) * chmcfg.max_chmpx_count * 2 +
+																					sizeof(MQMSGHEADLIST) * (chmcfg.max_server_mq_cnt + chmcfg.max_client_mq_cnt) +
+																					sizeof(CLTPROCLIST) * MAX_CLTPROCLIST_COUNT(chmcfg.max_client_mq_cnt, chmcfg.mqcnt_per_attach));
 		PCHMSOCKLIST	rel_chmsockarea			= reinterpret_cast<PCHMSOCKLIST>(	sizeof(CHMSHM) +
-																					sizeof(CHMPXLIST) * pchmcfg->max_chmpx_count +
-																					sizeof(PCHMPX) * pchmcfg->max_chmpx_count * 2 +
-																					sizeof(MQMSGHEADLIST) * (pchmcfg->max_server_mq_cnt + pchmcfg->max_client_mq_cnt) +
-																					sizeof(CLTPROCLIST) * MAX_CLTPROCLIST_COUNT(pchmcfg->max_client_mq_cnt, pchmcfg->mqcnt_per_attach) +
-																					sizeof(CHMLOGRAW) * pchmcfg->max_histlog_count);
+																					sizeof(CHMPXLIST) * chmcfg.max_chmpx_count +
+																					sizeof(PCHMPX) * chmcfg.max_chmpx_count * 2 +
+																					sizeof(MQMSGHEADLIST) * (chmcfg.max_server_mq_cnt + chmcfg.max_client_mq_cnt) +
+																					sizeof(CLTPROCLIST) * MAX_CLTPROCLIST_COUNT(chmcfg.max_client_mq_cnt, chmcfg.mqcnt_per_attach) +
+																					sizeof(CHMLOGRAW) * chmcfg.max_histlog_count);
 		PCHMPX*			rel_pchmpxarr_base		= rel_pchmpxarrarea;
-		PCHMPX*			rel_pchmpxarr_pend		= CHM_OFFSET(rel_pchmpxarrarea, static_cast<off_t>(sizeof(PCHMPX) * pchmcfg->max_chmpx_count), PCHMPX*);
+		PCHMPX*			rel_pchmpxarr_pend		= CHM_OFFSET(rel_pchmpxarrarea, static_cast<off_t>(sizeof(PCHMPX) * chmcfg.max_chmpx_count), PCHMPX*);
 
 		// initializing each area
 		{
 			PCHMPXLIST	chmpxlist = CHM_ABS(shmbase, rel_chmpxarea, PCHMPXLIST);
-			for(long cnt = 0L; cnt < pchmcfg->max_chmpx_count; cnt++){
+			for(long cnt = 0L; cnt < chmcfg.max_chmpx_count; cnt++){
 				PCHMPXLIST	prev = 0 < cnt ? &chmpxlist[cnt - 1] : NULL;
-				PCHMPXLIST	next = (cnt + 1 < pchmcfg->max_chmpx_count) ? &chmpxlist[cnt + 1] : NULL;
+				PCHMPXLIST	next = (cnt + 1 < chmcfg.max_chmpx_count) ? &chmpxlist[cnt + 1] : NULL;
 
 				chmpxlistlap	tmpchmpxlist(&chmpxlist[cnt], NULL, NULL, NULL, NULL, NULL, shmbase);		// absmapptr, chmpx*s are NULL, these can allow only here(calling only Initialize()).
 				if(!tmpchmpxlist.Initialize(prev, next)){
@@ -633,15 +633,15 @@ bool ChmIMData::InitializeShmEx(const CHMCFGINFO* pchmcfg, const CHMNODE_CFGINFO
 		}
 		{
 			PCHMPX*	pchmpxarr = CHM_ABS(shmbase, rel_pchmpxarrarea, PCHMPX*);
-			for(long cnt = 0L; cnt < (pchmcfg->max_chmpx_count * 2); cnt++){
+			for(long cnt = 0L; cnt < (chmcfg.max_chmpx_count * 2); cnt++){
 				pchmpxarr[cnt] = NULL;
 			}
 		}
 		{
 			PMQMSGHEADLIST	mqmsglist = CHM_ABS(shmbase, rel_chmpxmsgarea, PMQMSGHEADLIST);
-			for(long cnt = 0L; cnt < (pchmcfg->max_server_mq_cnt + pchmcfg->max_client_mq_cnt); cnt++){
+			for(long cnt = 0L; cnt < (chmcfg.max_server_mq_cnt + chmcfg.max_client_mq_cnt); cnt++){
 				PMQMSGHEADLIST	prev = (0 < cnt) ? &mqmsglist[cnt - 1] : NULL;
-				PMQMSGHEADLIST	next = (cnt + 1 < (pchmcfg->max_server_mq_cnt + pchmcfg->max_client_mq_cnt)) ? &mqmsglist[cnt + 1] : NULL;
+				PMQMSGHEADLIST	next = (cnt + 1 < (chmcfg.max_server_mq_cnt + chmcfg.max_client_mq_cnt)) ? &mqmsglist[cnt + 1] : NULL;
 
 				mqmsgheadlistlap	tmpmqmsgheadlist(&mqmsglist[cnt], shmbase);
 				if(!tmpmqmsgheadlist.Initialize(prev, next)){
@@ -653,7 +653,7 @@ bool ChmIMData::InitializeShmEx(const CHMCFGINFO* pchmcfg, const CHMNODE_CFGINFO
 		}
 		{
 			PCLTPROCLIST	cltproclist		= CHM_ABS(shmbase, rel_chmpxpidarea, PCLTPROCLIST);
-			long			cltproclist_cnt	= MAX_CLTPROCLIST_COUNT(pchmcfg->max_client_mq_cnt, pchmcfg->mqcnt_per_attach);
+			long			cltproclist_cnt	= MAX_CLTPROCLIST_COUNT(chmcfg.max_client_mq_cnt, chmcfg.mqcnt_per_attach);
 			for(long cnt = 0L; cnt < cltproclist_cnt; cnt++){
 				PCLTPROCLIST	prev = (0 < cnt) ? &cltproclist[cnt - 1] : NULL;
 				PCLTPROCLIST	next = (cnt + 1 < cltproclist_cnt) ? &cltproclist[cnt + 1] : NULL;
@@ -668,7 +668,7 @@ bool ChmIMData::InitializeShmEx(const CHMCFGINFO* pchmcfg, const CHMNODE_CFGINFO
 		}
 		{
 			PCHMLOGRAW	lograw = CHM_ABS(shmbase, rel_lograwarea, PCHMLOGRAW);
-			for(long cnt = 0L; cnt < pchmcfg->max_histlog_count; cnt++){
+			for(long cnt = 0L; cnt < chmcfg.max_histlog_count; cnt++){
 				chmlograwlap	tmplograw(&lograw[cnt], shmbase);
 				if(!tmplograw.Initialize()){
 					ERR_CHMPRN("Failed to initialize No.%ld CHMLOGRAW.", cnt);
@@ -679,7 +679,7 @@ bool ChmIMData::InitializeShmEx(const CHMCFGINFO* pchmcfg, const CHMNODE_CFGINFO
 		}
 		{
 			PCHMSOCKLIST	chmsocklist		= CHM_ABS(shmbase, rel_chmsockarea, PCHMSOCKLIST);
-			long			chmsocklist_cnt	= pchmcfg->max_chmpx_count * pchmcfg->max_sock_pool * 2;
+			long			chmsocklist_cnt	= chmcfg.max_chmpx_count * chmcfg.max_sock_pool * 2;
 			for(long cnt = 0L; cnt < chmsocklist_cnt; cnt++){
 				PCHMSOCKLIST	prev = (0 < cnt) ? &chmsocklist[cnt - 1] : NULL;
 				PCHMSOCKLIST	next = (cnt + 1 < chmsocklist_cnt) ? &chmsocklist[cnt + 1] : NULL;
@@ -702,7 +702,7 @@ bool ChmIMData::InitializeShmEx(const CHMCFGINFO* pchmcfg, const CHMNODE_CFGINFO
 
 		// CHMSHM.CHMLOG
 		chmloglap	tmpchmlog(&pChmBase->chmpxlog, shmbase);
-		if(!tmpchmlog.Initialize(rel_lograwarea, pchmcfg->max_histlog_count)){
+		if(!tmpchmlog.Initialize(rel_lograwarea, chmcfg.max_histlog_count)){
 			ERR_CHMPRN("Failed to initialize CHMLOG.");
 			CHM_MUMMAP(fd, shmbase, total_shmsize);
 			return false;
@@ -710,7 +710,7 @@ bool ChmIMData::InitializeShmEx(const CHMCFGINFO* pchmcfg, const CHMNODE_CFGINFO
 
 		// CHMSHM.CHMINFO
 		chminfolap	tmpchminfo(&pChmBase->info, shmbase);
-		if(!tmpchminfo.Initialize(pchmcfg, rel_chmpxmsgarea, pself, rel_chmpxarea, rel_chmpxpidarea, rel_chmsockarea, rel_pchmpxarr_base, rel_pchmpxarr_pend)){
+		if(!tmpchminfo.Initialize(&chmcfg, rel_chmpxmsgarea, pself, rel_chmpxarea, rel_chmpxpidarea, rel_chmsockarea, rel_pchmpxarr_base, rel_pchmpxarr_pend)){
 			ERR_CHMPRN("Failed to initialize CHMINFO.");
 			CHM_MUMMAP(fd, shmbase, total_shmsize);
 			return false;
@@ -739,19 +739,19 @@ bool ChmIMData::AttachShm(void)
 	}
 
 	// get config
-	const CHMCFGINFO*	pchmcfg = pConfObj->GetConfiguration();
-	if(!pchmcfg){
-		ERR_CHMPRN("Could not get configuration information structure pointer.");
+	CHMCFGINFO	chmcfg;
+	if(!pConfObj->GetConfiguration(chmcfg)){
+		ERR_CHMPRN("Could not get configuration information structure.");
 		return false;
 	}
-	if(MAX_GROUP_LENGTH <= pchmcfg->groupname.length()){
+	if(MAX_GROUP_LENGTH <= chmcfg.groupname.length()){
 		ERR_CHMPRN("Configuration information are wrong.");
 		return false;
 	}
 
 	// Check mq size
 	//
-	long	maxmsg = pchmcfg->max_mq_per_client + pchmcfg->max_server_mq_cnt;
+	long	maxmsg = chmcfg.max_mq_per_client + chmcfg.max_server_mq_cnt;
 	if(!ChmEventMq::InitializeMaxMqSystemSize(maxmsg)){
 		ERR_CHMPRN("Could not set mq size = %ld for client process.", maxmsg);
 		return false;
@@ -759,8 +759,8 @@ bool ChmIMData::AttachShm(void)
 
 	// make shm path
 	string	shmpath;
-	if(!ChmIMData::MakeShmFilePath(pchmcfg->groupname.c_str(), pchmcfg->self_ctlport, shmpath)){
-		ERR_CHMPRN("Failed to make chmshm file path from groupname(%s).", pchmcfg->groupname.c_str());
+	if(!ChmIMData::MakeShmFilePath(chmcfg.groupname.c_str(), chmcfg.self_ctlport, shmpath)){
+		ERR_CHMPRN("Failed to make chmshm file path from groupname(%s).", chmcfg.groupname.c_str());
 		return false;
 	}
 
@@ -812,9 +812,9 @@ bool ChmIMData::InitializeOther(void)
 		ERR_CHMPRN("Configuration object is not loaded.");
 		return false;
 	}
-	const CHMCFGINFO*	pchmcfg = pConfObj->GetConfiguration();
-	if(!pchmcfg){
-		ERR_CHMPRN("Could not get configuration information structure pointer.");
+	CHMCFGINFO	chmcfg;
+	if(!pConfObj->GetConfiguration(chmcfg)){
+		ERR_CHMPRN("Could not get configuration information structure.");
 		return false;
 	}
 	// clear hostname:ctlport cache
@@ -833,15 +833,14 @@ bool ChmIMData::ReloadConfiguration(void)
 		ERR_CHMPRN("Configuration object is not loaded.");
 		return false;
 	}
-	const CHMCFGINFO*	pchmcfg = pConfObj->GetConfiguration();
-	if(!pchmcfg){
-		ERR_CHMPRN("Could not get configuration information structure pointer.");
+	CHMCFGINFO	chmcfg;
+	if(!pConfObj->GetConfiguration(chmcfg)){
+		ERR_CHMPRN("Could not get configuration information structure.");
 		return false;
 	}
-
 	// reload
 	chminfolap	tmpchminfo(&pChmShm->info, pChmShm);
-	if(!tmpchminfo.ReloadConfiguration(pchmcfg)){
+	if(!tmpchminfo.ReloadConfiguration(&chmcfg)){
 		ERR_CHMPRN("Failed to reload configuration file.");
 		return false;
 	}

--- a/lib/chmimdata.h
+++ b/lib/chmimdata.h
@@ -80,7 +80,7 @@ class ChmIMData
 		off_t GetLockOffsetForMQ(void) const;
 		bool CloseShm(void);
 		bool InitializeShm(void);
-		bool InitializeShmEx(const CHMCFGINFO* pchmcfg, const CHMNODE_CFGINFO* pself);
+		bool InitializeShmEx(const CHMCFGINFO& chmcfg, const CHMNODE_CFGINFO* pself);
 		bool IsAttachedShm(void) const { return (NULL != pChmShm); }
 		bool AttachShm(void);													// For client process library
 		bool InitializeOther(void);

--- a/lib/chmnetdb.h
+++ b/lib/chmnetdb.h
@@ -86,10 +86,12 @@ class ChmNetDb
 		static bool GetLocalHostnameList(strlst_t& hostnames);
 		static bool GetLocalHostList(strlst_t& hostinfo, bool remove_localhost = false);
 		static bool GetAnyAddrInfo(short port, struct addrinfo** ppaddrinfo, bool is_inetv6);
-		static bool CvtAddrInfoToIpAddress(const struct sockaddr_storage* info, socklen_t infolen, std::string& stripaddress);
+		static bool CvtAddrInfoToIpAddress(struct sockaddr_storage* info, socklen_t infolen, std::string& stripaddress);
 		static bool CvtSockToLocalPort(int sock, short& port);
 		static bool CvtSockToPeerPort(int sock, short& port);
 		static bool CvtV4MappedAddrInfo(struct sockaddr_storage* info, socklen_t& addrlen);
+		static bool GetIPv4MappedIPv6Address(const char* target, std::string& stripv4);
+		static std::string CvtIPv4MappedIPv6Address(const std::string& target);
 		static void FreeAddrInfoList(addrinfolist_t& infolist);
 		static std::string GetNoZoneIndexIpAddress(const std::string& ipaddr);
 		static bool IsLocalhostKeyword(const char* host);

--- a/lib/chmregex.h
+++ b/lib/chmregex.h
@@ -27,8 +27,8 @@
 // Utilities
 //---------------------------------------------------------
 bool ExpandSimpleRegxHostname(const char* hostname, strlst_t& expand_lst, bool is_cvt_localhost, bool is_cvt_fqdn = true, bool is_strict = false);
-bool IsInHostnameList(const char* hostname, strlst_t& hostname_lst, std::string& matchhostname, bool is_cvt_localhost = false);
-bool IsMatchHostname(const char* hostname, strlst_t& regex_lst, std::string& matchhostname);
+bool IsInHostnameList(const char* target, strlst_t& hostname_list, std::string& foundname, bool is_cvt_localhost = false);
+bool IsMatchHostname(const char* target, strlst_t& regex_lst, std::string& foundname);
 
 #endif	// CHMREGEX_H
 

--- a/tests/chmpxconftest.cc
+++ b/tests/chmpxconftest.cc
@@ -61,30 +61,30 @@ static bool LoadConfTest(CHMConf* pconfobj)
 		return false;
 	}
 
-	const CHMCFGINFO*	pchmcfginfo = pconfobj->GetConfiguration(true);
-	if(!pchmcfginfo){
+	CHMCFGINFO	chmcfg;
+	if(!pconfobj->GetConfiguration(chmcfg, true)){
 		ERR_CHMPRN("Failed load configuration.");
 		return false;
 	}
 
 	// Dump
 	printf("configuration{\n");
-	printf("\tGROUP           = %s\n", pchmcfginfo->groupname.c_str());
-	printf("\tREVISION        = %ld\n", pchmcfginfo->revision);
-	printf("\tMAXCHMPX        = %ld\n", pchmcfginfo->max_chmpx_count);
-	printf("\tREPLICA         = %ld\n", pchmcfginfo->replica_count);
-	printf("\tMAXMQSERVER     = %ld\n", pchmcfginfo->max_server_mq_cnt);
-	printf("\tMAXMQCLIENT     = %ld\n", pchmcfginfo->max_client_mq_cnt);
-	printf("\tMQPERATTACH     = %ld\n", pchmcfginfo->mqcnt_per_attach);
-	printf("\tMAXQPERSERVERMQ = %ld\n", pchmcfginfo->max_q_per_servermq);
-	printf("\tMAXQPERCLIENTMQ = %ld\n", pchmcfginfo->max_q_per_clientmq);
-	printf("\tMAXMQPERCLIENT  = %ld\n", pchmcfginfo->max_mq_per_client);
-	printf("\tMAXHISTLOG      = %ld\n", pchmcfginfo->max_histlog_count);
-	printf("\tDATE            = %jd\n", static_cast<intmax_t>(pchmcfginfo->date));
+	printf("\tGROUP           = %s\n", chmcfg.groupname.c_str());
+	printf("\tREVISION        = %ld\n", chmcfg.revision);
+	printf("\tMAXCHMPX        = %ld\n", chmcfg.max_chmpx_count);
+	printf("\tREPLICA         = %ld\n", chmcfg.replica_count);
+	printf("\tMAXMQSERVER     = %ld\n", chmcfg.max_server_mq_cnt);
+	printf("\tMAXMQCLIENT     = %ld\n", chmcfg.max_client_mq_cnt);
+	printf("\tMQPERATTACH     = %ld\n", chmcfg.mqcnt_per_attach);
+	printf("\tMAXQPERSERVERMQ = %ld\n", chmcfg.max_q_per_servermq);
+	printf("\tMAXQPERCLIENTMQ = %ld\n", chmcfg.max_q_per_clientmq);
+	printf("\tMAXMQPERCLIENT  = %ld\n", chmcfg.max_mq_per_client);
+	printf("\tMAXHISTLOG      = %ld\n", chmcfg.max_histlog_count);
+	printf("\tDATE            = %jd\n", static_cast<intmax_t>(chmcfg.date));
 
 	int count = 1;
 	chmnode_cfginfos_t::const_iterator	iter;
-	for(iter = pchmcfginfo->servers.begin(); iter != pchmcfginfo->servers.end(); ++iter, ++count){
+	for(iter = chmcfg.servers.begin(); iter != chmcfg.servers.end(); ++iter, ++count){
 		printf("\tserver[%d]{\n", count);
 		printf("\t\tNAME          = %s\n", iter->name.c_str());
 		printf("\t\tPORT          = %d\n", iter->port);
@@ -103,7 +103,7 @@ static bool LoadConfTest(CHMConf* pconfobj)
 	}
 
 	count = 1;
-	for(iter = pchmcfginfo->slaves.begin(); iter != pchmcfginfo->slaves.end(); ++iter, ++count){
+	for(iter = chmcfg.slaves.begin(); iter != chmcfg.slaves.end(); ++iter, ++count){
 		printf("\tserver[%d]{\n", count);
 		printf("\t\tNAME          = %s\n", iter->name.c_str());
 		printf("\t\tPORT          = %d\n", iter->port);

--- a/tests/chmpxlinetool.cc
+++ b/tests/chmpxlinetool.cc
@@ -1488,8 +1488,8 @@ static bool load_initial_chmpx_nodes(nodectrllist_t& nodes, const string& strCon
 			PRN("You can see detail about error, execute this program with \"-d\"(\"-g\") option.");
 			return false;
 		}
-		const CHMCFGINFO*	pchmcfg = pConfObj->GetConfiguration();
-		if(!pchmcfg){
+		CHMCFGINFO	chmcfg;
+		if(!pConfObj->GetConfiguration(chmcfg, true)){
 			ERR("Something error occurred in getting chmpx nodes information from configuration(%s).", strConfig.c_str());
 			pConfObj->Clean();
 			CHM_Delete(pConfObj);
@@ -1502,14 +1502,14 @@ static bool load_initial_chmpx_nodes(nodectrllist_t& nodes, const string& strCon
 		chmnode_cfginfos_t::const_iterator	iter;
 
 		// loop to get all server nodes
-		for(iter = pchmcfg->servers.begin(); iter != pchmcfg->servers.end(); ++iter){
+		for(iter = chmcfg.servers.begin(); iter != chmcfg.servers.end(); ++iter){
 			newnode.hostname	= iter->name;
 			newnode.ctrlport	= iter->ctlport;
 			newnode.is_server	= true;
 			nodes.push_back(newnode);
 		}
 		// loop to get all slave nodes
-		for(iter = pchmcfg->slaves.begin(); iter != pchmcfg->slaves.end(); ++iter){
+		for(iter = chmcfg.slaves.begin(); iter != chmcfg.slaves.end(); ++iter){
 			newnode.hostname	= iter->name;
 			newnode.ctrlport	= iter->ctlport;
 			newnode.is_server	= false;

--- a/tests/chmpxlinetool.cc
+++ b/tests/chmpxlinetool.cc
@@ -1031,7 +1031,9 @@ static bool ExecOptionParser(int argc, char** argv, option_t& opts, string& prgn
 		return false;
 	}
 	prgname = basename(argv[0]);
-	if(string::npos == prgname.find("lt-")){
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress stlIfStrFind
+	if(0 == prgname.find("lt-")){
 		// cut "lt-"
 		prgname = prgname.substr(3);
 	}
@@ -2411,13 +2413,17 @@ static string ParseChmpxListFromDumpResult(nodectrllist_t& nodes, const string& 
 	strInput = strInput.substr(pos + strlen(DUMP_KEY_START));
 
 	// Loop to "}\n"
-	while(string::npos != strInput.find(DUMP_KEY_END) && string::npos != strInput.find(DUMP_KEY_END)){
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress stlIfStrFind
+	while(0 != strInput.find(DUMP_KEY_END) && string::npos != strInput.find(DUMP_KEY_END)){
 		string	name;
 		string	strctrlport;
 		short	ctrlport;
 
 		// "[XX]={\n"
-		if(string::npos == strInput.find(DUMP_KEY_ARRAY_START) || string::npos != strInput.find(DUMP_KEY_ARRAY_START)){
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress stlIfStrFind
+		if(string::npos == strInput.find(DUMP_KEY_ARRAY_START) || 0 != strInput.find(DUMP_KEY_ARRAY_START)){
 			MSG("Could not found \"[XX]={\" key or found invalid data in DUMP result.");
 			return strInput;
 		}
@@ -2487,7 +2493,9 @@ static string ParseChmpxListFromDumpResult(nodectrllist_t& nodes, const string& 
 			return strInput;
 		}
 	}
-	if(string::npos != strInput.find(DUMP_KEY_END)){
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress stlIfStrFind
+	if(0 != strInput.find(DUMP_KEY_END)){
 		ERR("Could not found end of chmpx \"}\" key in DUMP result.");
 		is_error = true;
 		return strInput;
@@ -2807,9 +2815,13 @@ static string ParseUnitDatasFromDumpResult(NODEUNITDATA& self, nodesunits_t& uni
 	strInput = strInput.substr(pos + strlen(DUMP_KEY_START));
 
 	// Loop to "}\n"
-	while(string::npos != strInput.find(DUMP_KEY_END) && string::npos != strInput.find(DUMP_KEY_END)){
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress stlIfStrFind
+	while(0 != strInput.find(DUMP_KEY_END) && string::npos != strInput.find(DUMP_KEY_END)){
 		// "[XX]={\n"
-		if(string::npos == strInput.find(DUMP_KEY_ARRAY_START) || string::npos != strInput.find(DUMP_KEY_ARRAY_START)){
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress stlIfStrFind
+		if(string::npos == strInput.find(DUMP_KEY_ARRAY_START) || 0 != strInput.find(DUMP_KEY_ARRAY_START)){
 			MSG("Could not found \"[XX]={\" key or found invalid data in DUMP result.");
 			return strInput;
 		}
@@ -2835,7 +2847,9 @@ static string ParseUnitDatasFromDumpResult(NODEUNITDATA& self, nodesunits_t& uni
 		string		hostport= MakeHostCtrlport(unitdata.hostname, unitdata.ctrlport);
 		unitdatas[hostport]	= unitdata;
 	}
-	if(string::npos != strInput.find(DUMP_KEY_END)){
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress stlIfStrFind
+	if(0 != strInput.find(DUMP_KEY_END)){
 		ERR("Could not found end of chmpx \"}\" key in DUMP result.");
 		return strInput;
 	}
@@ -3771,7 +3785,9 @@ static string CvtAllStatusResult(const string& strResult, bool& is_error)
 
 		// Get Server Name as "VerifyPeer="
 		string	strIsVerify;
-		if(isSSL && string::npos == (pos = strInput.find(ALLSTATUS_KEY_ISVERIFY))){
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress stlIfStrFind
+		if(isSSL && 0 == (pos = strInput.find(ALLSTATUS_KEY_ISVERIFY))){
 			strInput = strInput.substr(pos + strlen(ALLSTATUS_KEY_ISVERIFY));
 			if(string::npos == (pos = strInput.find(ALLSTATUS_KEY_CR))){
 				ERR("Could not found CR after \"Verify Peer=\" key in ALLSTATUS result.");


### PR DESCRIPTION
## Relevant Issue (if applicable)
#31 

## Details
### Fixed correction mistakes for cppcheck
There was a correction mistake in correcting the cppcheck error of #31.

### Host matching improvements
- The node can be specified by IP address.  
You can also register as a server node on a HOST that does not have a hostname registered (no FQDN).
- IPv4-Mapped IPv6 Address  
Added support for IPv4-Mapped IPv6 Address (RFC 4291).
- Specification of multiple HOSTs  
Multiple HOSTs can be specified in the NAME element during configuration.　　
Multiple HOSTs can be specified using a comma(",").

### Fixed bugs
Some parts are not multi-thread safe and have been fixed.