### PR TITLE
Fixed bugs about reverse peer and etc

### DIFF
--- a/lib/chmconf.h
+++ b/lib/chmconf.h
@@ -589,14 +589,15 @@ class CHMConf : public ChmEventBase
 		virtual bool LoadConfiguration(CHMCFGINFO& chmcfginfo) const = 0;
 
 		const CHMCFGINFO* GetConfiguration(bool is_check_update = false);		// thread unsafe
-		bool RawCheckContainsNodeInfoList(const char* hostname, const short* pctlport, const char* cuk, bool with_forward, bool with_reverse, chmnode_cfginfos_t* pnodeinfos, strlst_t* pnormnames, bool is_server, bool is_check_update = false);
+		bool RawCheckContainsNodeInfoList(const char* hostname, const short* pctlport, const char* cuk, bool with_forward, chmnode_cfginfos_t* pnodeinfos, strlst_t* pnormnames, bool is_server, bool is_check_update = false);
 		bool CheckContainsServerInfoList(const char* hostname, chmnode_cfginfos_t* pnodeinfos, strlst_t* pnormnames, bool is_check_update = false);
 		bool CheckContainsSlaveInfoList(const char* hostname, chmnode_cfginfos_t* pnodeinfos, strlst_t* pnormnames, bool is_check_update = false);
-		bool RawCheckContainsNodeInfo(const char* hostname, const CHMNODE_CFGINFO& nodeinfos, std::string& normalizedname, bool is_server, bool with_forward, bool with_reverse);
+		bool RawCheckContainsNodeInfo(const char* hostname, const CHMNODE_CFGINFO& nodeinfos, std::string& normalizedname, bool is_server, bool with_forward);
 		bool GetServerInfo(const char* hostname, short ctlport, const char* cuk, CHMNODE_CFGINFO& svrnodeinfo, std::string& normalizedname, bool is_check_update = false);
 		bool GetSelfServerInfo(CHMNODE_CFGINFO& svrnodeinfo, std::string& normalizedname, bool is_check_update = false);
 		bool GetSlaveInfo(const char* hostname, short ctlport, const char* cuk, CHMNODE_CFGINFO& slvnodeinfo, std::string& normalizedname, bool is_check_update = false);
 		bool GetSelfSlaveInfo(CHMNODE_CFGINFO& slvnodeinfo, std::string& normalizedname, bool is_check_update = false);
+		bool GetSelfReversePeer(hostport_list_t& reverse_peers, bool& is_server);
 
 		bool IsWatching(void) const { return (CHM_INVALID_HANDLE != watchfd); }
 		uint CheckNotifyEvent(void);
@@ -631,6 +632,8 @@ class CHMConf : public ChmEventBase
 		bool CheckContainsNodeInfoList(const char* hostname, chmnode_cfginfos_t* pnodeinfos, strlst_t* pnormnames, bool is_check_update = false);
 		bool GetNodeInfo(const char* hostname, short ctlport, const char* cuk, CHMNODE_CFGINFO& nodeinfo, std::string& normalizedname, bool is_only_server, bool is_check_update = false);
 		bool GetSelfNodeInfo(CHMNODE_CFGINFO& nodeinfo, std::string& normalizedname, bool is_check_update = false);
+		bool IsSelfReversePeer(const char* hostname);
+		bool SearchContainsNodeInfoList(short ctlport, const char* cuk, CHMNODE_CFGINFO& nodeinfo, std::string& normalizedname, bool is_server, bool is_check_update = false);
 
 		bool GetServerList(strlst_t& server_list);
 		bool IsServerList(const char* hostname, std::string& fqdn);

--- a/lib/chmeventsock.cc
+++ b/lib/chmeventsock.cc
@@ -7605,9 +7605,11 @@ bool ChmEventSock::PxComReceiveStatusReq(PCOMHEAD pComHead, PPXCOM_ALL pComAll, 
 		pStatusRes->count				= count;
 		pStatusRes->pchmpxsvr_offset	= sizeof(PXCOM_N2_STATUS_RES);
 
-		unsigned char*	pbyres			= CHM_OFFSET(pStatusRes, sizeof(PXCOM_N2_STATUS_RES), unsigned char*);
-		if(pchmpxsvrs && 0 < count){
-			memcpy(pbyres, pchmpxsvrs, sizeof(CHMPXSVR) * count);
+		PCHMPXSVR	pchmpxsvrsv2		= CHM_OFFSET(pStatusRes, sizeof(PXCOM_N2_STATUS_RES), PCHMPXSVR);
+		if(pchmpxsvrs && pchmpxsvrsv2 && 0 < count){
+			for(long pos = 0; pos < count; ++pos){
+				COPY_PCHMPXSVR(&pchmpxsvrsv2[pos], &pchmpxsvrs[pos]);
+			}
 		}
 	}else{
 		// old version

--- a/lib/chmregex.cc
+++ b/lib/chmregex.cc
@@ -281,6 +281,23 @@ static bool expand_simple_regexes(const string& simple_regexes, strlst_t& expand
 	return true;
 }
 
+// [NOTE]
+// This is a simple host name check function.
+//
+bool IsSimpleRegexHostname(const char* hostname)
+{
+	for(; !CHMEMPTYSTR(hostname); ++hostname){
+		// [NOTE]
+		// Returns true if hostanme may be other than FQDN and IP address.
+		// That is, if it contains characters other than alphabets, numbers, '-', '.', and ':'.
+		//
+		if(0 == isalnum(*hostname) && '.' != *hostname && ':' != *hostname && '-' != *hostname){
+			return true;
+		}
+	}
+	return false;
+}
+
 //---------------------------------------------------------
 // Utilities
 //---------------------------------------------------------

--- a/lib/chmregex.h
+++ b/lib/chmregex.h
@@ -26,6 +26,7 @@
 //---------------------------------------------------------
 // Utilities
 //---------------------------------------------------------
+bool IsSimpleRegexHostname(const char* hostname);
 bool ExpandSimpleRegxHostname(const char* hostname, strlst_t& expand_lst, bool is_cvt_localhost, bool is_cvt_fqdn = true, bool is_strict = false);
 bool IsInHostnameList(const char* target, strlst_t& hostname_list, std::string& foundname, bool is_cvt_localhost = false);
 bool IsMatchHostname(const char* target, strlst_t& regex_lst, std::string& foundname);

--- a/lib/chmstructure.h
+++ b/lib/chmstructure.h
@@ -635,7 +635,7 @@ typedef struct chm_sock_list{
 typedef struct chmpx_host_port_raw_pair{
 	char			name[NI_MAXHOST];					// = 1025 for getnameinfo()
 	short			port;
-}CHMPXHP_RAWPAIR, *PCHMPXHP_RAWPAIR;
+}CHMPX_ATTR_PACKED CHMPXHP_RAWPAIR, *PCHMPXHP_RAWPAIR;
 
 //---------------------------------
 // Chmpx
@@ -1005,16 +1005,16 @@ typedef struct chmpx_server_v1{
 			{ \
 				int	_hton_hostport_pair_cnt; \
 				for(_hton_hostport_pair_cnt = 0; _hton_hostport_pair_cnt < EXTERNAL_EP_MAX; ++_hton_hostport_pair_cnt){ \
-					(pdata)->endpoints[_hton_hostport_pair_cnt].port = be64toh((pdata)->endpoints[_hton_hostport_pair_cnt].port); \
+					(pdata)->endpoints[_hton_hostport_pair_cnt].port = be16toh((pdata)->endpoints[_hton_hostport_pair_cnt].port); \
 				} \
 				for(_hton_hostport_pair_cnt = 0; _hton_hostport_pair_cnt < EXTERNAL_EP_MAX; ++_hton_hostport_pair_cnt){ \
-					(pdata)->ctlendpoints[_hton_hostport_pair_cnt].port = be64toh((pdata)->ctlendpoints[_hton_hostport_pair_cnt].port); \
+					(pdata)->ctlendpoints[_hton_hostport_pair_cnt].port = be16toh((pdata)->ctlendpoints[_hton_hostport_pair_cnt].port); \
 				} \
 				for(_hton_hostport_pair_cnt = 0; _hton_hostport_pair_cnt < FORWARD_PEER_MAX; ++_hton_hostport_pair_cnt){ \
-					(pdata)->forward_peers[_hton_hostport_pair_cnt].port = be64toh((pdata)->forward_peers[_hton_hostport_pair_cnt].port); \
+					(pdata)->forward_peers[_hton_hostport_pair_cnt].port = be16toh((pdata)->forward_peers[_hton_hostport_pair_cnt].port); \
 				} \
 				for(_hton_hostport_pair_cnt = 0; _hton_hostport_pair_cnt < REVERSE_PEER_MAX; ++_hton_hostport_pair_cnt){ \
-					(pdata)->reverse_peers[_hton_hostport_pair_cnt].port = be64toh((pdata)->reverse_peers[_hton_hostport_pair_cnt].port); \
+					(pdata)->reverse_peers[_hton_hostport_pair_cnt].port = be16toh((pdata)->reverse_peers[_hton_hostport_pair_cnt].port); \
 				} \
 			} \
 		}


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Fixed bugs about reverse peer
There was a bug in the specification of reverse peer judgment, and it was fixed.
When connecting via reverse peer, the connection source node needs at least the control port number. (hope CUK is also set)

### Fixed bugs about port at initializing
In the initial connection, there was a problem that the port number could not be set when connecting to the server node.
