### PR TITLE
Updated files for release 1.0.74

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+chmpx (1.0.74) unstable; urgency=low
+
+  * Fixed bugs about reverse peer and etc - #43
+  * Changed to not check expiration date in merge process - #42
+  * Fixed code for cppcheck 1.90 - #41
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Fri, 03 Apr 2020 17:54:26 +0900
+
 chmpx (1.0.73) unstable; urgency=low
 
   * Fixed a bug about complete auto merging - #38

--- a/buildutils/chmpx.spec.in
+++ b/buildutils/chmpx.spec.in
@@ -52,8 +52,8 @@ License: @PKGLICENSE@
 @RPMPKG_GROUP@
 URL: https://@GIT_DOMAIN@/@GIT_ORG@/@PACKAGE_NAME@
 Source0: https://@GIT_DOMAIN@/@GIT_ORG@/@PACKAGE_NAME@/archive/%{gittag}/%{name}-%{version}.tar.gz
-Requires: k2hash%{?_isa} >= 1.0.71, libfullock%{?_isa} >= 1.0.36
-BuildRequires: git-core gcc-c++ make libtool k2hash-devel >= 1.0.71, libfullock-devel >= 1.0.36
+Requires: k2hash%{?_isa} >= 1.0.74, libfullock%{?_isa} >= 1.0.36
+BuildRequires: git-core gcc-c++ make libtool k2hash-devel >= 1.0.74, libfullock-devel >= 1.0.36
 
 %description
 @LONGDESC@
@@ -104,7 +104,7 @@ rm -rf %{buildroot}
 #
 %package devel
 Summary: @SHORTDESC@ (development)
-Requires: %{name}%{?_isa} = %{version}-%{release}, k2hash-devel%{?_isa} >= 1.0.71, libfullock-devel%{?_isa} >= 1.0.36
+Requires: %{name}%{?_isa} = %{version}-%{release}, k2hash-devel%{?_isa} >= 1.0.74, libfullock-devel%{?_isa} >= 1.0.36
 
 %description devel
 Development package for building with @PACKAGE_NAME@ shared library.

--- a/buildutils/control.in
+++ b/buildutils/control.in
@@ -2,7 +2,7 @@ Source: @PACKAGE_NAME@
 Section: net
 Priority: optional
 Maintainer: @DEV_NAME@ <@DEV_EMAIL@>
-Build-Depends: @DEBHELPER_DEP@, k2hash-dev (>= 1.0.71), libfullock-dev (>= 1.0.36), libyaml-dev
+Build-Depends: @DEBHELPER_DEP@, k2hash-dev (>= 1.0.74), libfullock-dev (>= 1.0.36), libyaml-dev
 Depends: ${misc:Depends}
 Standards-Version: 3.9.8
 Homepage: https://@GIT_DOMAIN@/@GIT_ORG@/@GIT_REPO@
@@ -14,7 +14,7 @@ Section: devel
 Architecture: amd64
 Conflicts: chmproxy-dev
 Replaces: chmproxy-dev
-Depends: ${misc:Depends}, @PACKAGE_NAME@ (= ${binary:Version}), k2hash-dev (>= 1.0.71), libfullock-dev (>= 1.0.36), libyaml-dev
+Depends: ${misc:Depends}, @PACKAGE_NAME@ (= ${binary:Version}), k2hash-dev (>= 1.0.74), libfullock-dev (>= 1.0.36), libyaml-dev
 Description: @SHORTDESC@ (development)
  Development package for building with @PACKAGE_NAME@ shared library.
   This package has header files and symbols for it.
@@ -24,6 +24,6 @@ Section: net
 Architecture: amd64
 Conflicts: chmproxy
 Replaces: chmproxy
-Depends: ${shlibs:Depends}, ${misc:Depends}, k2hash (>= 1.0.71), libfullock (>= 1.0.36)
+Depends: ${shlibs:Depends}, ${misc:Depends}, k2hash (>= 1.0.74), libfullock (>= 1.0.36)
 Description: @SHORTDESC@
 @DEBLONGDESC@

--- a/configure.ac
+++ b/configure.ac
@@ -214,7 +214,7 @@ AC_ARG_ENABLE(check-depend-libs,
 	esac]
 )
 AS_IF([test ${check_depend_libs} = 1], [AC_MSG_RESULT(yes)], [AC_MSG_RESULT(no)])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([k2hash], [libk2hash >= 1.0.71], [], [AC_MSG_ERROR(not found k2hash package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([k2hash], [libk2hash >= 1.0.74], [], [AC_MSG_ERROR(not found k2hash package)])])
 AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([fullock], [libfullock >= 1.0.36], [], [AC_MSG_ERROR(not found libfullock package)])])
 
 #


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Changes from 1.0.73 to 1.0.74
- Fixed bugs about reverse peer and etc - #43
- Changed to not check expiration date in merge process - #42
- Fixed code for cppcheck 1.90 - #41

