### PR TITLE
Added checking resolv for hostname

### DIFF
--- a/buildutils/travis_builder.sh
+++ b/buildutils/travis_builder.sh
@@ -316,7 +316,8 @@ fi
 # For packagecloud.io CLI tool(package_cloud)
 #
 if [ ${IS_CENTOS} -ne 1 ]; then
-	run_cmd ${GEM_BIN} install rake rubocop package_cloud
+	run_cmd ${GEM_BIN} install rubocop -v 0.81.0
+	run_cmd ${GEM_BIN} install rake package_cloud
 else
 	#
 	# Using RHSCL because centos has older ruby
@@ -324,7 +325,8 @@ else
 	run_cmd ${INSTALLER_BIN} install -y -qq centos-release-scl
 	run_cmd ${INSTALLER_BIN} install -y -qq rh-ruby23 rh-ruby23-ruby-devel rh-ruby23-rubygem-rake
 	source /opt/rh/rh-ruby23/enable
-	run_cmd ${GEM_BIN} install rubocop package_cloud
+	run_cmd ${GEM_BIN} install rubocop -v 0.81.0
+	run_cmd ${GEM_BIN} install package_cloud
 fi
 
 #

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -105,7 +105,7 @@ nodist_pkginclude_HEADERS	= chmssgnutls.h
 endif
 
 libchmpx_la_LDFLAGS	= -version-info $(LIB_VERSION_INFO)
-libchmpx_la_LIBADD	= $(k2hash_LIBS) $(fullock_LIBS) $(SSL_TLS_LIBS) -lyaml -lrt -lpthread
+libchmpx_la_LIBADD	= $(k2hash_LIBS) $(fullock_LIBS) $(SSL_TLS_LIBS) -lyaml -lrt -lresolv -lpthread
 
 ACLOCAL_AMFLAGS		= -I m4
 AM_CFLAGS			= $(k2hash_CFLAGS) $(fullock_CFLAGS)

--- a/lib/chmnetdb.h
+++ b/lib/chmnetdb.h
@@ -63,6 +63,8 @@ class ChmNetDb
 		bool				is_init_regobj;		//
 
 	protected:
+		static bool CheckHostnameInResolv(const char* hostname, bool is_default_domain = false);
+
 		ChmNetDb();
 		virtual ~ChmNetDb();
 


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Added checking resolv for hostname
Always, immediately after starting CHMPX, the host name of Localhost is checked.
However, if the host name is set to `hostname` or `hosts`, it cannot be resolved inside CHMPX other than itself.
Therefore, the host name that is not the FQDN registered in DNS cannot be used.

### Ruby(rubocop) version
Fixed the rubocop version in TravisCI.
This is because problems occur with the current version of rubocop in an environment below Ruby 2.4.0.
