### PR TITLE
Supported regular expression to CUK in slave setting

### DIFF
--- a/lib/chmconf.cc
+++ b/lib/chmconf.cc
@@ -765,7 +765,7 @@ bool CHMConf::RawCheckContainsNodeInfoList(const char* hostname, const short* pc
 				}
 
 			}else{
-				if(pctlport && (CHM_INVALID_PORT == *pctlport || *pctlport == iter->ctlport) && strcuk == iter->cuk){
+				if(pctlport && (CHM_INVALID_PORT == *pctlport || *pctlport == iter->ctlport) && IsMatchCuk(strcuk, iter->cuk)){
 					// strictly matched
 					if(pnodeinfos){
 						pnodeinfos->push_back(*iter);
@@ -1081,7 +1081,7 @@ bool CHMConf::SearchContainsNodeInfoList(short ctlport, const char* cuk, CHMNODE
 	chmnode_cfginfos_t*	pcfgnodelist = is_server ? &(pchmcfginfo->servers) : &(pchmcfginfo->slaves);
 	for(chmnode_cfginfos_t::const_iterator iter = pcfgnodelist->begin(); pcfgnodelist->end() != iter; ++iter){
 		// compare ctlport and cuk, hostname must not be (simple) regex.
-		if(!IsSimpleRegexHostname(iter->name.c_str()) && (CHM_INVALID_PORT == ctlport || ctlport == iter->ctlport) && strcuk == iter->cuk){
+		if(!IsSimpleRegexHostname(iter->name.c_str()) && (CHM_INVALID_PORT == ctlport || ctlport == iter->ctlport) && IsMatchCuk(strcuk, iter->cuk)){
 			// found node
 			nodeinfo		= *iter;
 			normalizedname	= iter->name;

--- a/lib/chmregex.cc
+++ b/lib/chmregex.cc
@@ -456,6 +456,32 @@ bool IsMatchHostname(const char* target, strlst_t& regex_lst, string& foundname)
 	return false;
 }
 
+// For CUK matching
+//
+// Regular expressions are allowed in the CUK specification of the slave node.
+// This function uses regular expressions when doing CUK matching.
+//
+bool IsMatchCuk(const string& cuk, const string& basecuk)
+{
+	if(cuk.empty() && basecuk.empty()){
+		return true;
+	}else if(basecuk.empty()){
+		return false;
+	}else if(cuk == basecuk){
+		return true;
+	}
+	regex_t	regex_obj;
+	int		result;
+	if(0 != (result = regcomp(&regex_obj, basecuk.c_str(), REG_EXTENDED | REG_NOSUB))){
+		MSG_CHMPRN("Failed to compile regex for %s with return code(%d).", basecuk.c_str(), result);
+		return false;
+	}
+	result = regexec(&regex_obj, cuk.c_str(), 0, NULL, 0);
+	regfree(&regex_obj);
+
+	return (0 == result);
+}
+
 /*
  * VIM modelines
  *

--- a/lib/chmregex.h
+++ b/lib/chmregex.h
@@ -30,6 +30,7 @@ bool IsSimpleRegexHostname(const char* hostname);
 bool ExpandSimpleRegxHostname(const char* hostname, strlst_t& expand_lst, bool is_cvt_localhost, bool is_cvt_fqdn = true, bool is_strict = false);
 bool IsInHostnameList(const char* target, strlst_t& hostname_list, std::string& foundname, bool is_cvt_localhost = false);
 bool IsMatchHostname(const char* target, strlst_t& regex_lst, std::string& foundname);
+bool IsMatchCuk(const std::string& cuk, const std::string& basecuk);
 
 #endif	// CHMREGEX_H
 

--- a/lib/chmstructure.tcc
+++ b/lib/chmstructure.tcc
@@ -6144,7 +6144,7 @@ bool chmpxman_lap<T>::RawCheckContainsChmpxSvrs(const char* hostname, const shor
 				MSG_CHMPRN("Hostname(%s) is matched(not strictly) name(%s):chmpxid(0x%016" PRIx64 ") to globalname(%s).", hostname, name.c_str(), chmpxid, globalname.c_str());
 				return true;
 			}
-			if(pctlport && (CHM_INVALID_PORT == *pctlport || *pctlport == ctlport) && strcuk == cuk){
+			if(pctlport && (CHM_INVALID_PORT == *pctlport || *pctlport == ctlport) && IsMatchCuk(strcuk, cuk)){
 				// strictly matched
 				if(pnormalizedname){
 					*pnormalizedname = globalname;
@@ -6177,7 +6177,7 @@ bool chmpxman_lap<T>::RawCheckContainsChmpxSvrs(const char* hostname, const shor
 				MSG_CHMPRN("Hostname(%s) is matched(not strictly) forward peer in name(%s):chmpxid(0x%016" PRIx64 ") to globalname(%s).", hostname, name.c_str(), chmpxid, globalname.c_str());
 				return true;
 			}
-			if((CHM_INVALID_PORT == *pctlport || *pctlport == ctlport) && strcuk == cuk){
+			if((CHM_INVALID_PORT == *pctlport || *pctlport == ctlport) && IsMatchCuk(strcuk, cuk)){
 				// strictly matched
 				if(pnormalizedname){
 					*pnormalizedname = globalname;


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
When CHMPXIDTYPE is CUK in the configuration, it is needed to specify wildcards for the CUK to the slave node in configuation for server nodes.
At this PR, it was made possible to use regular expressions like `CUK=[.]*`.
The slave node side configuration specifies each slave's CUK, but the server node side can be set to ANY.
This configuration was previously disallowed and is now allowed.

