### PR TITLE
Allowed unspecified CUSTOM_ID_SEED of slave node

### DIFF
--- a/lib/chmconf.cc
+++ b/lib/chmconf.cc
@@ -2438,8 +2438,7 @@ bool CHMIniConf::LoadConfiguration(CHMCFGINFO& chmcfginfo) const
 
 		if(iter->end() == iter->find(INICFG_CUSTOM_ID_SEED_STR)){
 			if(CHMPXID_SEED_CUSTOM == chmcfginfo.chmpxid_type){
-				MSG_CHMPRN("configuration file(%s) does not have \"%s\" in %s server node in %s section, but chmpxid seed needs \"custom seed\".", cfgfile.c_str(), INICFG_CUSTOM_ID_SEED_STR, slvnode.name.c_str(), INICFG_SLVNODE_SEC_STR);
-				return false;
+				MSG_CHMPRN("configuration file(%s) does not have \"%s\" in %s server node in %s section, but chmpxid seed needs \"custom seed\". Then sets seed is empty string for slave node temporarily.", cfgfile.c_str(), INICFG_CUSTOM_ID_SEED_STR, slvnode.name.c_str(), INICFG_SLVNODE_SEC_STR);
 			}
 			slvnode.custom_seed.clear();
 		}else{
@@ -3741,8 +3740,7 @@ static bool ChmYamlLoadConfigurationSlvnodeSec(yaml_parser_t& yparser, CHMCFGINF
 				}
 				if(CHMPXID_SEED_CUSTOM == chmcfginfo.chmpxid_type){
 					if(slvnode.custom_seed.empty()){
-						ERR_CHMPRN("Not found CUSTOM_SEED value in %s section, but chmpxid seed is from \"custom seed\".", CFG_SLVNODE_SEC_STR);
-						result = false;
+						WAN_CHMPRN("Not found CUSTOM_SEED value in %s section, but chmpxid seed is from \"custom seed\". Then sets seed is empty string for slave node temporarily.", CFG_SLVNODE_SEC_STR);
 					}
 				}else{
 					if(!slvnode.custom_seed.empty()){


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
When `CHMPXIDTYPE` was set to `CUSTOM`, the `CUSTOM_ID_SEED` key was required for the setting information of each node.

The server node leaves the setting of `CUSTOM_ID_SEED` as mandatory, but allows it even if it is not specified in the case of a slave node.
This is because the value of `CUSTOM_ID_SEED` is not necessary for matching the node at the time of connection, and the value sent by the connection request side is used by overwriting.
Since the configuration of the slave node can use wildcards, in the case of wildcards, `ANY` for `CUSTOM_ID_SEED` can be set as like as  `CUK` and `ANY` means `not-set CUSTOM_ID_SEED key`.
But in the settings of the slave node itself, a Configuration with `CUSTOM_ID_SEED` is required. 

If chmpx is started without setting this key, chmpxid cannot match and a connection error will occur.