### PR TITLE
Delete server nodes when updating the configuration

### DIFF
--- a/lib/chmconf.cc
+++ b/lib/chmconf.cc
@@ -2272,7 +2272,7 @@ bool CHMIniConf::LoadConfiguration(CHMCFGINFO& chmcfginfo) const
 		//
 		strlst_t	expand_svrnodes;
 		expand_svrnodes.clear();
-		if(!ExpandSimpleRegxHostname(svrnode.name.c_str(), expand_svrnodes, true, true, false)){	// convert localhost to server name and query FQDN.
+		if(!ExpandSimpleRegexHostname(svrnode.name.c_str(), expand_svrnodes, true, true, false)){	// convert localhost to server name and query FQDN.
 			MSG_CHMPRN("Failed to expand server node name(%s).", svrnode.name.c_str());
 			return false;
 		}
@@ -3316,7 +3316,7 @@ static bool ChmYamlLoadConfigurationSvrnodeSec(yaml_parser_t& yparser, CHMCFGINF
 				// So that, we expand server node name here.
 				//
 				strlst_t	expand_svrnodes;
-				if(!ExpandSimpleRegxHostname(svrnode.name.c_str(), expand_svrnodes, true, true, false)){	// convert localhost to server name and query FQDN.
+				if(!ExpandSimpleRegexHostname(svrnode.name.c_str(), expand_svrnodes, true, true, false)){	// convert localhost to server name and query FQDN.
 					ERR_CHMPRN("Failed to expand server node name(%s).", svrnode.name.c_str());
 					result = false;
 

--- a/lib/chmimdata.cc
+++ b/lib/chmimdata.cc
@@ -844,7 +844,7 @@ bool ChmIMData::ReloadConfiguration(void)
 	}
 	// reload
 	chminfolap	tmpchminfo(&pChmShm->info, pChmShm);
-	if(!tmpchminfo.ReloadConfiguration(&chmcfg)){
+	if(!tmpchminfo.ReloadConfiguration(&chmcfg, eqfd)){
 		ERR_CHMPRN("Failed to reload configuration file.");
 		return false;
 	}

--- a/lib/chmregex.cc
+++ b/lib/chmregex.cc
@@ -310,7 +310,7 @@ bool IsSimpleRegexHostname(const char* hostname)
 // If is_cvt_localhost is true, hostname which is "localhost"
 // or "127.0.0.1" or "::1" is changed FQDN.
 //
-bool ExpandSimpleRegxHostname(const char* hostname, strlst_t& expand_lst, bool is_cvt_localhost, bool is_cvt_fqdn, bool is_strict)
+bool ExpandSimpleRegexHostname(const char* hostname, strlst_t& expand_lst, bool is_cvt_localhost, bool is_cvt_fqdn, bool is_strict)
 {
 	if(CHMEMPTYSTR(hostname)){
 		ERR_CHMPRN("Parameter is NULL.");
@@ -330,7 +330,7 @@ bool ExpandSimpleRegxHostname(const char* hostname, strlst_t& expand_lst, bool i
 //
 // This function is checking hostname in expanded hostname list
 // for server list. The hostname_list should be expanded by 
-// ExpandSimpleRegxHostname() with is_cvt_localhost = true and 
+// ExpandSimpleRegexHostname() with is_cvt_localhost = true and 
 // is_cvt_fqdn = true.
 // If the hostname matches in array, foundname is set as
 // matched hostname(FQDN or localhost or IP address).
@@ -354,7 +354,7 @@ bool IsInHostnameList(const char* target, strlst_t& hostname_list, string& found
 	for(strlst_t::const_iterator hostname_list_iter = hostname_list.begin(); hostname_list_iter != hostname_list.end(); ++hostname_list_iter){
 		strlst_t	tmp_hostname_list;
 		// check simple regex
-		if(!ExpandSimpleRegxHostname(hostname_list_iter->c_str(), tmp_hostname_list, is_cvt_localhost, true, false)){
+		if(!ExpandSimpleRegexHostname(hostname_list_iter->c_str(), tmp_hostname_list, is_cvt_localhost, true, false)){
 			// hostname_list_iter->c_str() is not simple regex
 			tmp_hostname_list.push_back(*hostname_list_iter);
 		}

--- a/lib/chmregex.h
+++ b/lib/chmregex.h
@@ -27,7 +27,7 @@
 // Utilities
 //---------------------------------------------------------
 bool IsSimpleRegexHostname(const char* hostname);
-bool ExpandSimpleRegxHostname(const char* hostname, strlst_t& expand_lst, bool is_cvt_localhost, bool is_cvt_fqdn = true, bool is_strict = false);
+bool ExpandSimpleRegexHostname(const char* hostname, strlst_t& expand_lst, bool is_cvt_localhost, bool is_cvt_fqdn = true, bool is_strict = false);
 bool IsInHostnameList(const char* target, strlst_t& hostname_list, std::string& foundname, bool is_cvt_localhost = false);
 bool IsMatchHostname(const char* target, strlst_t& regex_lst, std::string& foundname);
 bool IsMatchCuk(const std::string& cuk, const std::string& basecuk);


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Until now, even if the configuration was updated and the server node was reduced, the server node was not deleted from the information (SHM) managed by CHMPX.
Even if the server node remains in this way, there is no problem in operation.
However, if the number of server nodes increases/decreases rapidly, there is a risk that the SHM area will be used up eventually.
Therefore, if the server node is deleted and the server node is in `SERVICEOUT`/`DOWN`/`NOACT` status, the target server node is deleted from the management information.
In addition, in cases other than this status, it is necessary to change the status, so deletion is not performed at this timing.
Therefore, deletion is not strict, but there is no problem as a countermeasure when the number of server nodes increases or decreases.

In the slave node, it is deleted when the SERVICE OUT/DOWN/NOACT status is reached, so no modificaton for like this is required.

Besides this, I corrected the misspelling.

