### PR TITLE
Changed the file descriptor etc. used in the shared lock

### DIFF
--- a/lib/chmimdata.cc
+++ b/lib/chmimdata.cc
@@ -501,6 +501,8 @@ bool ChmIMData::CloseShm(void)
 	CHM_MUMMAP(ShmFd, pChmShm, ShmSize);
 	ChmpxPid = CHM_INVALID_PID;
 
+	ChmLock::UnsetChmShmFd();
+
 	return result;
 }
 
@@ -728,6 +730,8 @@ bool ChmIMData::InitializeShmEx(const CHMCFGINFO& chmcfg, const CHMNODE_CFGINFO*
 	ShmFd	= fd;
 	ShmSize	= total_shmsize;
 
+	ChmLock::SetChmShmFd(ShmFd);
+
 	return true;
 }
 
@@ -806,6 +810,8 @@ bool ChmIMData::AttachShm(void)
 	pChmShm = reinterpret_cast<PCHMSHM>(shmbase);
 	ShmFd	= fd;
 	ShmSize	= total_shmsize;
+
+	ChmLock::SetChmShmFd(ShmFd);
 
 	return true;
 }
@@ -1094,6 +1100,7 @@ bool ChmIMData::MergeChmpxSvrs(PCHMPXSVR pchmpxsvrs, long count, bool is_remove,
 	ChmLock	AutoLock(CHMLT_IMDATA, CHMLT_WRITE);			// Lock
 
 	chminfolap	tmpchminfo(&pChmShm->info, pChmShm);
+
 	return tmpchminfo.MergeChmpxSvrs(pchmpxsvrs, count, is_remove, is_init_process, eqfd);
 }
 

--- a/lib/chmlock.h
+++ b/lib/chmlock.h
@@ -55,12 +55,17 @@ typedef enum chm_lock_type{
 class ChmLock : public FLRwlRcsv
 {
 	protected:
+		static int		chmshmfd;		// SHM for CHMPX
+
 		CHMLOCKKIND		kind;			// Lock target kind
 
 	protected:
 		ChmLock(void);					// Not use by any
 
 	public:
+		static int SetChmShmFd(int fd);
+		static int UnsetChmShmFd(void);
+
 		ChmLock(CHMLOCKKIND LockKind, CHMLOCKTYPE LockType);
 		ChmLock(CHMLOCKTYPE LockType, int TargetFd, off_t FileOffset);
 		virtual ~ChmLock();


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Changed the lock processing to Shared Memory area for internal management data of CHMPX.

Until now, CHMPX used a fictitious file descriptor as the lock target for exclusive control of a part of the area, but changed this to mmap file descriptor.
We also changed the offset for the shared lock.
The file descriptor for the modified lock is set on Shared Memory initialization and released on close.

