### PR TITLE
Fixed the process in adding/removing nodes to/from a running cluster

### DIFF
--- a/lib/chmconf.cc
+++ b/lib/chmconf.cc
@@ -648,8 +648,15 @@ bool CHMConf::CheckUpdate(void)
 
 	// Load configuration file.
 	if(!LoadConfiguration(*pnewinfo)){
-		ERR_CHMPRN("Failed to load configuration from %s.", cfgfile.c_str());
+		ERR_CHMPRN("Failed to load configuration from %s, thus this is fatal error.", cfgfile.c_str());
 		CHM_Delete(pnewinfo);
+
+		// [NOTE]
+		// If there is something wrong with the configuration
+		// (for example, if it does not have self setting),
+		// then terminate the process.
+		ChmCntrl::LoopBreakHandler(SIGHUP);
+
 		return false;
 	}
 

--- a/lib/chmstructure.tcc
+++ b/lib/chmstructure.tcc
@@ -5880,30 +5880,35 @@ bool chmpxman_lap<T>::MergeChmpxSvrs(PCHMPXSVR pchmpxsvrs, CHMPXID_SEED_TYPE typ
 				is_error = true;
 				continue;
 			}
-			// make new chmpx(list) from free chmpx list
-			chmpxlistlap	freechmpxlist(basic_type::pAbsPtr->chmpx_frees, basic_type::pAbsPtr->chmpxid_map, AbsBaseArr(), AbsPendArr(), AbsSockFreeCnt(), AbsSockFrees(), basic_type::pShmBase, false);	// From Relative
-			chmpxlistlap	newchmpxlist(freechmpxlist.PopAny(), basic_type::pAbsPtr->chmpxid_map, AbsBaseArr(), AbsPendArr(), AbsSockFreeCnt(), AbsSockFrees(), basic_type::pShmBase);	// Get one CHMPXLIST from Absolute
-			chmpxlap		newchmpx(newchmpxlist.GetAbsChmpxPtr(), AbsBaseArr(), AbsPendArr(), AbsSockFreeCnt(), AbsSockFrees(), basic_type::pShmBase);								// Get CHMPX from Absolute
+			if(CHMPXSTS_SRVOUT_DOWN_NORMAL == pchmpxsvrs[cnt].status){
+				WAN_CHMPRN("CHMPX(%s: 0x%016" PRIx64 ") from CHMPXSVR is SERVICEOUT / DOWN status, thus it is not added server list.", pchmpxsvrs[cnt].name, pchmpxsvrs[cnt].chmpxid);
 
-			basic_type::pAbsPtr->chmpx_free_count--;
-			basic_type::pAbsPtr->chmpx_frees = freechmpxlist.GetFirstPtr(false);
-
-			newchmpxlist.Clear();
-
-			if(!newchmpx.InitializeServer(&pchmpxsvrs[cnt], basic_type::pAbsPtr->group, type)){
-				WAN_CHMPRN("Failed to initialize CHMPX(%s: 0x%016" PRIx64 ") from CHMPXSVR, but continue...", pchmpxsvrs[cnt].name, pchmpxsvrs[cnt].chmpxid);
-			}
-
-			if(svrchmpxlist.GetAbsPtr()){
-				// insert
-				svrchmpxlist.Insert(newchmpxlist.GetAbsPtr(), true, type);					// From abs
-				basic_type::pAbsPtr->chmpx_server_count++;
-				basic_type::pAbsPtr->chmpx_servers = svrchmpxlist.GetFirstPtr(false);
 			}else{
-				// insert new
-				newchmpxlist.SaveChmpxIdMap();												// Set chmpxid map
-				basic_type::pAbsPtr->chmpx_slave_count	= 1;
-				basic_type::pAbsPtr->chmpx_servers		= newchmpxlist.GetRelPtr();
+				// make new chmpx(list) from free chmpx list
+				chmpxlistlap	freechmpxlist(basic_type::pAbsPtr->chmpx_frees, basic_type::pAbsPtr->chmpxid_map, AbsBaseArr(), AbsPendArr(), AbsSockFreeCnt(), AbsSockFrees(), basic_type::pShmBase, false);	// From Relative
+				chmpxlistlap	newchmpxlist(freechmpxlist.PopAny(), basic_type::pAbsPtr->chmpxid_map, AbsBaseArr(), AbsPendArr(), AbsSockFreeCnt(), AbsSockFrees(), basic_type::pShmBase);	// Get one CHMPXLIST from Absolute
+				chmpxlap		newchmpx(newchmpxlist.GetAbsChmpxPtr(), AbsBaseArr(), AbsPendArr(), AbsSockFreeCnt(), AbsSockFrees(), basic_type::pShmBase);								// Get CHMPX from Absolute
+
+				basic_type::pAbsPtr->chmpx_free_count--;
+				basic_type::pAbsPtr->chmpx_frees = freechmpxlist.GetFirstPtr(false);
+
+				newchmpxlist.Clear();
+
+				if(!newchmpx.InitializeServer(&pchmpxsvrs[cnt], basic_type::pAbsPtr->group, type)){
+					WAN_CHMPRN("Failed to initialize CHMPX(%s: 0x%016" PRIx64 ") from CHMPXSVR, but continue...", pchmpxsvrs[cnt].name, pchmpxsvrs[cnt].chmpxid);
+				}
+
+				if(svrchmpxlist.GetAbsPtr()){
+					// insert
+					svrchmpxlist.Insert(newchmpxlist.GetAbsPtr(), true, type);					// From abs
+					basic_type::pAbsPtr->chmpx_server_count++;
+					basic_type::pAbsPtr->chmpx_servers = svrchmpxlist.GetFirstPtr(false);
+				}else{
+					// insert new
+					newchmpxlist.SaveChmpxIdMap();												// Set chmpxid map
+					basic_type::pAbsPtr->chmpx_server_count	= 1;
+					basic_type::pAbsPtr->chmpx_servers		= newchmpxlist.GetRelPtr();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Fixed the process of adding/deleting nodes while the cluster is running.

Strictly corrected the behavior when a server node that is a cluster element is deleted from Configuration.
In this case, it works as follows.

- The target server node automatically terminates the process.
- The internal management information of the nodes deleted from the non-target server nodes and slave nodes is also deleted.

If a node is added, the operation will be as follows depending on the conditions.

- After adding, if the target node is not started yet, it will not be added to the internal management information of the server/slave node.
- When the target node starts, it is added to the internal management information of the server/slave node and connected.

