### PR TITLE
Fixed a parameter and display host format

### DIFF
--- a/tests/chmpxlinetool.cc
+++ b/tests/chmpxlinetool.cc
@@ -2785,9 +2785,12 @@ static bool CreateDynaTargetChmpx(void)
 //
 // utility for key
 //
+// Format
+// 		"hostname(IP address)":"control port":"cuk":"custom_seed":"control endpoints..."
+//
 static string MakeMapKeyFromAll(const string& hostname, short ctrlport, const string& cuk, const string& ctlendpoints, const string& custom_seed)
 {
-	string	hostall	= hostname + string(":") + to_string(ctrlport) + string(":") + ctlendpoints + string(":") + custom_seed;
+	string	hostall	= hostname + string(":") + to_string(ctrlport) + string(":") + cuk + string(":") + custom_seed + string(":") + ctlendpoints ;
 	return hostall;
 }
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Fixed a bug in chmpxlinetool.

The format of the display name of the server/slave node that chmpxlinetool lists was incorrect.
I fixed this to the correct format.

