### PR TITLE
Enhanced logic for initial connection of server nodes

### DIFF
--- a/lib/chmcntrl.cc
+++ b/lib/chmcntrl.cc
@@ -520,6 +520,23 @@ bool ChmCntrl::EventLoop(void)
 						}
 					}
 				}
+			}else if(pEventSock){
+				// Server node
+				if(1L >= ImData.GetUpServerCount()){
+					// [NOTE]
+					// This case is that there are no other server node up.
+					if(pEventSock->InitialAllServerStatus()){
+						if(1L < ImData.GetUpServerCount()){
+							// Try to connect servers
+							//MSG_CHMPRN("Try to connect servers on RING(mode is SERVER).");
+							pEventSock->ConnectRing();		// not need to check result.
+						}else{
+							// sleep
+							struct timespec	sleeptime = {0, 100 * 1000 * 1000};		// 100ms
+							nanosleep(&sleeptime, NULL);
+						}
+					}
+				}
 			}
 			continue;
 		}

--- a/lib/chmeventsock.h
+++ b/lib/chmeventsock.h
@@ -207,7 +207,6 @@ class ChmEventSock : public ChmEventBase
 		// connect/accept
 		bool ConnectServer(chmpxid_t chmpxid, int& sock, bool without_set_imdata);
 		bool RawConnectServer(chmpxid_t chmpxid, int& sock, bool without_set_imdata, bool is_lock);
-		bool ConnectRing(void);
 		bool CloseRechainRing(chmpxid_t nowchmpxid);
 		bool RechainRing(chmpxid_t newchmpxid);
 		bool CheckRechainRing(chmpxid_t newchmpxid, bool& is_rechain);
@@ -314,6 +313,7 @@ class ChmEventSock : public ChmEventBase
 		virtual ~ChmEventSock();
 
 		bool InitialAllServerStatus(void);
+		bool ConnectRing(void);
 		bool ConnectServers(void);
 		bool DoSuspend(void);
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
#### background
When the server node is started, it checks whether other server nodes are started according to the contents of Configuration.
And if it can't communicate with other server nodes, it will start the cluster which will have only self server node.
The server nodes on this case start will independently form a cluster for each nodes.

#### Issues and corrections
If the server nodes start at the same time, each server node may form an independent cluster as described above.
Therefore, the server node that configures the cluster that has only one node checks the other server nodes regularly.
If the other server node is already up, it will join the cluster of the other server node.

