### PR TITLE
Fixed slave node startup failure when resolv is different

### DIFF
--- a/lib/chmstructure.tcc
+++ b/lib/chmstructure.tcc
@@ -1747,8 +1747,14 @@ bool chmpx_lap<T>::MergeChmpxSvr(PCHMPXSVR chmpxsvr, bool is_force, int eqfd)
 		ERR_CHMPRN("PCHMPX does not set.");
 		return false;
 	}
+
+	// for name checking
+	std::string	foundname;
+	strlst_t	node_list;
+	node_list.push_back(chmpxsvr->name);
+
 	if(is_force){
-		if(0 != strcmp(basic_type::pAbsPtr->name, chmpxsvr->name) || basic_type::pAbsPtr->chmpxid != chmpxsvr->chmpxid){
+		if(basic_type::pAbsPtr->chmpxid != chmpxsvr->chmpxid || !IsInHostnameList(basic_type::pAbsPtr->name, node_list, foundname, true)){
 			strcpy(basic_type::pAbsPtr->name, chmpxsvr->name);
 			basic_type::pAbsPtr->chmpxid = chmpxsvr->chmpxid;
 		}
@@ -1808,7 +1814,7 @@ bool chmpx_lap<T>::MergeChmpxSvr(PCHMPXSVR chmpxsvr, bool is_force, int eqfd)
 		}
 
 	}else{
-		if(0 != strcmp(basic_type::pAbsPtr->name, chmpxsvr->name) || basic_type::pAbsPtr->chmpxid != chmpxsvr->chmpxid){
+		if(basic_type::pAbsPtr->chmpxid != chmpxsvr->chmpxid || !IsInHostnameList(basic_type::pAbsPtr->name, node_list, foundname, true)){
 			ERR_CHMPRN("name(%s - %s) or chmpxid(0x%016" PRIx64 " - 0x%016" PRIx64 ") is different.", basic_type::pAbsPtr->name, chmpxsvr->name, basic_type::pAbsPtr->chmpxid, chmpxsvr->chmpxid);
 			return false;
 		}


### PR DESCRIPTION
### Relevant Issue (if applicable)
#45

### Details
When slave node with different DNS specified in resolv.conf is started, connection to server node RING may not be possible.  
This is because the HOST IP or FQDN of the slave node may be different from the server node.  
Since there was a leak in the correction due to the function addition in #344, It was fixed.
