### PR TITLE
Updated files for release 1.0.82

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+chmpx (1.0.82) unstable; urgency=low
+
+  * Fixed chmpxlinetool bug for nodes with different resolv - #66
+  * Fixed slave node startup failure when resolv is different - #65
+  * Fixed merge failure at discarding internal data of DOWN snode - #64
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Wed, 26 Aug 2020 20:05:20 +0900
+
 chmpx (1.0.81) unstable; urgency=low
 
   * Fixed a bug of dynamic addition/deletion of server nodes - #62


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Changes from 1.0.81 to 1.0.82
- Fixed chmpxlinetool bug for nodes with different resolv - #66
- Fixed slave node startup failure when resolv is different - #65
- Fixed merge failure at discarding internal data of DOWN snode - #64 