### PR TITLE
Reverted and fixed again about the shared lock

### DIFF
--- a/lib/chmimdata.cc
+++ b/lib/chmimdata.cc
@@ -556,8 +556,6 @@ bool ChmIMData::CloseShm(void)
 	CHM_MUMMAP(ShmFd, pChmShm, ShmSize);
 	ChmpxPid = CHM_INVALID_PID;
 
-	ChmLock::UnsetChmShmFd();
-
 	return result;
 }
 
@@ -785,8 +783,6 @@ bool ChmIMData::InitializeShmEx(const CHMCFGINFO& chmcfg, const CHMNODE_CFGINFO*
 	ShmFd	= fd;
 	ShmSize	= total_shmsize;
 
-	ChmLock::SetChmShmFd(ShmFd);
-
 	return true;
 }
 
@@ -865,8 +861,6 @@ bool ChmIMData::AttachShm(void)
 	pChmShm = reinterpret_cast<PCHMSHM>(shmbase);
 	ShmFd	= fd;
 	ShmSize	= total_shmsize;
-
-	ChmLock::SetChmShmFd(ShmFd);
 
 	return true;
 }
@@ -1155,7 +1149,6 @@ bool ChmIMData::MergeChmpxSvrs(PCHMPXSVR pchmpxsvrs, long count, bool is_remove,
 	ChmLock	AutoLock(CHMLT_IMDATA, CHMLT_WRITE);			// Lock
 
 	chminfolap	tmpchminfo(&pChmShm->info, pChmShm);
-
 	return tmpchminfo.MergeChmpxSvrs(pchmpxsvrs, count, is_remove, is_init_process, eqfd);
 }
 

--- a/lib/chmlock.cc
+++ b/lib/chmlock.cc
@@ -27,7 +27,6 @@
 #include "chmcommon.h"
 #include "chmutil.h"
 #include "chmlock.h"
-#include "chmstructure.h"
 #include "chmdbg.h"
 
 using namespace	std;
@@ -35,47 +34,20 @@ using namespace	std;
 //---------------------------------------------------------
 // Utility Macros
 //---------------------------------------------------------
-// [NOTE]
-// The lock target is the file descriptor of ChmShm.
-// Locks other than CHMLT_MQ lock and share the first 3 bytes
-// of ChmShm.
-// This area is a buffer for the version number and does not
-// affect operations other than this lock. Therefore, these 3
-// bytes are used.
-//
-#define	CHMLOCK_OFFSET_LOCKTYPE(LockType)		(	(CHMLT_IMDATA	== LockType) ? 0L : \
-													(CHMLT_SOCKET	== LockType) ? 1L : \
-													(CHMLT_MQOBJ	== LockType) ? 2L : \
-													0L )
-
-//---------------------------------------------------------
-// Class Variables
-//---------------------------------------------------------
-int	ChmLock::chmshmfd = CHM_INVALID_HANDLE;
-
-//---------------------------------------------------------
-// Class Methods
-//---------------------------------------------------------
-int ChmLock::SetChmShmFd(int fd)
-{
-	int	oldfd			= ChmLock::chmshmfd;
-	ChmLock::chmshmfd	= fd;
-	return oldfd;
-}
-
-int ChmLock::UnsetChmShmFd(void)
-{
-	return ChmLock::SetChmShmFd(CHM_INVALID_HANDLE);
-}
+#define	CHMLOCK_NO_FD_LOCKTYPE(LockType)		FLCK_RWLOCK_NO_FD( \
+													LockType == CHMLT_IMDATA	? (getpid() | 0x1000000) : \
+													LockType == CHMLT_SOCKET	? (getpid() | 0x2000000) : \
+													LockType == CHMLT_MQOBJ		? (getpid() | 0x3000000) : \
+													0 )
 
 //---------------------------------------------------------
 // Methods
 //---------------------------------------------------------
-ChmLock::ChmLock(void) : FLRwlRcsv(ChmLock::chmshmfd, CHMLOCK_OFFSET_LOCKTYPE(CHMLT_IMDATA), 1L), kind(CHMLT_IMDATA)
+ChmLock::ChmLock(void) : FLRwlRcsv(FLCK_INVALID_HANDLE, 0L, 1L), kind(CHMLT_IMDATA)
 {
 }
 
-ChmLock::ChmLock(CHMLOCKKIND LockKind, CHMLOCKTYPE LockType) : FLRwlRcsv(ChmLock::chmshmfd, CHMLOCK_OFFSET_LOCKTYPE(LockKind), 1L, (CHMLT_READ == LockType)), kind(LockKind)
+ChmLock::ChmLock(CHMLOCKKIND LockKind, CHMLOCKTYPE LockType) : FLRwlRcsv(CHMLOCK_NO_FD_LOCKTYPE(LockKind), 0L, 1L, (CHMLT_READ == LockType)), kind(LockKind)
 {
 	assert(CHMLT_MQ != LockKind);
 }

--- a/lib/chmlock.h
+++ b/lib/chmlock.h
@@ -55,17 +55,12 @@ typedef enum chm_lock_type{
 class ChmLock : public FLRwlRcsv
 {
 	protected:
-		static int		chmshmfd;		// SHM for CHMPX
-
 		CHMLOCKKIND		kind;			// Lock target kind
 
 	protected:
 		ChmLock(void);					// Not use by any
 
 	public:
-		static int SetChmShmFd(int fd);
-		static int UnsetChmShmFd(void);
-
 		ChmLock(CHMLOCKKIND LockKind, CHMLOCKTYPE LockType);
 		ChmLock(CHMLOCKTYPE LockType, int TargetFd, off_t FileOffset);
 		virtual ~ChmLock();


### PR DESCRIPTION
### Relevant Issue (if applicable)
#53
### Details
Reverted #53 PR.
This is because the PR#53 may be incorrect and may have reduced performance under certain conditions.
Also, the symbol value reverted by this PR is changed.
There had been a problem with this symbol value and fixed it in #53.
Therefore, in this PR it was modified to change this symbol value.

