### PR TITLE
Updated files for release 1.0.83

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+chmpx (1.0.83) unstable; urgency=low
+
+  * Reverted and fixed again about the shared lock - #68
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Mon, 31 Aug 2020 13:54:48 +0900
+
 chmpx (1.0.82) unstable; urgency=low
 
   * Fixed chmpxlinetool bug for nodes with different resolv - #66


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Changes from 1.0.82 to 1.0.83
- Reverted and fixed again about the shared lock - #68

