### PR TITLE
Enhanced inspection for hostnames that cannot be resolved

### DIFF
--- a/lib/chmimdata.h
+++ b/lib/chmimdata.h
@@ -74,7 +74,8 @@ class ChmIMData
 		static bool MakeFilePath(const char* groupname, short port, MKFPMODE mode, std::string& shmpath);
 		static bool MakeShmFilePath(const char* groupname, short port, std::string& shmpath);
 		static bool MakeK2hashFilePath(const char* groupname, short port, std::string& shmpath);
-		static bool CompareChmpxSvrs(PCHMPXSVR pbase, long bcount, PCHMPXSVR pmerge, long mcount, bool is_status = true, bool ignore_down = true);
+		static bool CompareChmpxNameAndCustomSeed(const CHMPXSVR& src1, const CHMPXSVR& src2, bool is_check_custom_seed);
+		static bool CompareChmpxSvrs(PCHMPXSVR pbase, long bcount, PCHMPXSVR pmerge, long mcount, bool is_check_custom_seed, bool is_status = true, bool ignore_down = true);
 
 		off_t GetLockOffsetForMQ(void) const;
 		bool CloseShm(void);


### PR DESCRIPTION
#### Relevant Issue (if applicable)
n/a

#### Details
If you run CHMPX on a host that has a hostname that cannot be resolved, an error will occur.
This is because the CHMPX node name cannot be set as common information(DNS FQDN).
To avoid this, you can set the configuration to use CUSTOM_SEED.
However, even if CUSTOM_SEED is specified, a problem will occur if the hostname cannot be resolved.
This PR solved this.
