### PR TITLE
Fixed centos8 build and removed centos6 build

### DIFF
--- a/.github/workflows/build_helper.sh
+++ b/.github/workflows/build_helper.sh
@@ -522,9 +522,9 @@ if [ ${IS_OS_CENTOS} -eq 1 ]; then
 		run_cmd ${INSTALLER_BIN} --enablerepo=epel install -y ${INSTALL_QUIET_ARG} cppcheck
 	else
 		#
-		# For CentOS8, it is installed from PowerTools
+		# For CentOS8, it is installed from PowerTools( PwoerTools -> powertools at 2020/12 )
 		#
-		run_cmd ${INSTALLER_BIN} --enablerepo=PowerTools install -y ${INSTALL_QUIET_ARG} cppcheck
+		run_cmd ${INSTALLER_BIN} --enablerepo=powertools install -y ${INSTALL_QUIET_ARG} cppcheck
 	fi
 else
 	#

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,6 @@ jobs:
           - debian:stretch
           - centos:centos8
           - centos:centos7
-          - centos:centos6
           - fedora:32
           - fedora:31
           - fedora:30

--- a/.github/workflows/ostypevars.sh
+++ b/.github/workflows/ostypevars.sh
@@ -147,25 +147,13 @@ elif [ "X${CI_OSTYPE}" = "Xcentos:8" -o "X${CI_OSTYPE}" = "Xcentos:centos8" ]; t
 	IS_OS_CENTOS=1
 
 	# [NOTE]
-	# For CentOS8, installing libyaml-devel from PowerTools
+	# For CentOS8, installing libyaml-devel from PowerTools( PwoerTools -> powertools at 2020/12 )
 	#
 	dnf update -y -qq
-	dnf --enablerepo=PowerTools install -y libyaml-devel
+	dnf --enablerepo=powertools install -y libyaml-devel
 
 elif [ "X${CI_OSTYPE}" = "Xcentos:7" -o "X${CI_OSTYPE}" = "Xcentos:centos7" ]; then
 	DIST_TAG="el/7"
-	INSTALL_PKG_LIST="git autoconf automake gcc gcc-c++ gdb make libtool pkgconfig redhat-rpm-config rpm-build ruby-devel rubygems procps libyaml-devel k2hash-devel nss-devel"
-	CONFIGURE_EXT_OPT="--with-nss"
-	INSTALLER_BIN="yum"
-	INSTALL_QUIET_ARG=""
-	PKG_TYPE_DEB=0
-	PKG_TYPE_RPM=1
-	PKG_OUTPUT_DIR="."
-	PKG_EXT="rpm"
-	IS_OS_CENTOS=1
-
-elif [ "X${CI_OSTYPE}" = "Xcentos:6" -o "X${CI_OSTYPE}" = "Xcentos:centos6" ]; then
-	DIST_TAG="el/6"
 	INSTALL_PKG_LIST="git autoconf automake gcc gcc-c++ gdb make libtool pkgconfig redhat-rpm-config rpm-build ruby-devel rubygems procps libyaml-devel k2hash-devel nss-devel"
 	CONFIGURE_EXT_OPT="--with-nss"
 	INSTALLER_BIN="yum"


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### CentOS 8 Build
The CentOS 8 `PowerTools` repository has been renamed to `powertools` and has been fixed.

### CentOS 6 Build
Since the CentOS 6 package repository has been deleted, the backup (snapshot) repository does not build well, and CentOS 6 is no longer supported, we have discontinued building on CentOS 6.
