### PR TITLE
Drops Fedora28 and CentOS6.x from our support OS

### DIFF
--- a/build.md
+++ b/build.md
@@ -55,7 +55,7 @@ This section instructs how to install each dependent library and the header file
 
 **Note**: As I described in the previous section, [K2HASH Build](https://k2hash.antpick.ax/build.html) build option affects the **CHMPX** build option. See the Table1 in the previous section.
 
-For DebianStretch or Ubuntu(Bionic Beaver) users, follow the steps below:
+For recent Debian-based Linux distributions users, follow the steps below:
 ```bash
 $ sudo apt-get update -y
 $ sudo apt-get install curl -y
@@ -66,7 +66,18 @@ $ sudo apt-get install autoconf autotools-dev gcc g++ make gdb libtool pkg-confi
 $ sudo apt-get install git -y
 ```
 
-For Fedora28 or CentOS7.x(6.x) users, follow the steps below:
+For users who use supported Fedora other than latest version, follow the steps below:
+```bash
+$ sudo dnf makecache
+$ sudo dnf install curl -y
+$ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh \
+    | sudo bash
+$ sudo dnf install autoconf automake gcc gcc-c++ gdb make libtool pkgconfig \
+    libyaml-devel libfullock-devel k2hash-devel nss-devel -y
+$ sudo dnf install git -y
+```
+
+For other recent RPM-based Linux distributions users, follow the steps below:
 ```bash
 $ sudo yum makecache
 $ sudo yum install curl -y
@@ -88,7 +99,7 @@ $ git clone https://github.com/yahoojapan/chmpx.git
 
 Just follow the steps below to build **CHMPX** and install it. We use [GNU Automake](https://www.gnu.org/software/automake/) to build **CHMPX**.
 
-For DebianStretch or Ubuntu(Bionic Beaver) users, follow the steps below:
+For recent Debian-based Linux distributions users, follow the steps below:
 ```bash
 $ cd chmpx
 $ sh autogen.sh
@@ -97,7 +108,7 @@ $ make
 $ sudo make install
 ```
 
-For Fedora28 or CentOS7.x(6.x) users, follow the steps below:
+For recent RPM-based Linux distributions users, follow the steps below:
 ```bash
 $ cd chmpx
 $ sh autogen.sh

--- a/buildja.md
+++ b/buildja.md
@@ -55,7 +55,7 @@ SSL/TLSプロトコルを実装するアプリケーションは、1つのSSL/TL
 
 **注**：前のセクションで説明したように、[K2HASH Build](https://k2hash.antpick.ax/buildja.html)のビルドオプションは**CHMPX**ビルドオプションに影響します。 前のセクションの表1を参照してください。
 
-DebianStretchまたはUbuntu（Bionic Beaver）をお使いの場合は、以下の手順に従ってください。
+最近のDebianベースLinuxの利用者は、以下の手順に従ってください。
 ```bash
 $ sudo apt-get update -y
 $ sudo apt-get install curl -y
@@ -66,7 +66,18 @@ $ sudo apt-get install autoconf autotools-dev gcc g++ make gdb libtool pkg-confi
 $ sudo apt-get install git -y
 ```
 
-Fedora28またはCentOS7.x（6.x）ユーザーの場合は、以下の手順に従ってください。
+Fedoraの利用者は、以下の手順に従ってください。
+```bash
+$ sudo dnf makecache
+$ sudo dnf install curl -y
+$ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh \
+    | sudo bash
+$ sudo dnf install autoconf automake gcc gcc-c++ gdb make libtool pkgconfig \
+    libyaml-devel libfullock-devel k2hash-devel nss-devel -y
+$ sudo dnf install git -y
+```
+
+その他最近のRPMベースのLinuxの場合は、以下の手順に従ってください。
 ```bash
 $ sudo yum makecache
 $ sudo yum install curl -y
@@ -89,7 +100,7 @@ $ git clone https://github.com/yahoojapan/chmpx.git
 
 以下の手順に従って**CHMPX**をビルドしてインストールしてください。 [GNU Automake](https://www.gnu.org/software/automake/)を使って**CHMPX**を構築します。
 
-DebianStretchまたはUbuntu（Bionic Beaver）をお使いの場合は、以下の手順に従ってください。
+DebianベースLinuxの場合は、以下の手順に従ってください。
 ```bash
 $ cd chmpx
 $ sh autogen.sh
@@ -98,7 +109,7 @@ $ make
 $ sudo make install
 ```
 
-Fedora28またはCentOS7.x（6.x）ユーザーの場合は、以下の手順に従ってください。
+RPMベースLinuxの場合は、以下の手順に従ってください。
 ```bash
 $ cd chmpx
 $ sh autogen.sh

--- a/feature.md
+++ b/feature.md
@@ -14,6 +14,10 @@ next_string: Details
 ---
 
 # Feature
+
+## Flexible installation
+We provide suitable CHMPX installation for your OS. If you use Ubuntu, CentOS, Fedora or Debian, you can easily install it from [packagecloud.io] (https://packagecloud.io/antpickax/stable). Even if you use none of them, you can use it by [Build] (https://chmpx.antpick.ax/build.html) by yourself.
+
 ## Connections
 CHMPX program takes two types, server node and slave node.  
 The server node operates mainly on the host on which the server program providing the resource such as data/service/function.  

--- a/featureja.md
+++ b/featureja.md
@@ -14,6 +14,10 @@ next_string: Details
 ---
 
 # 特徴
+
+## 柔軟なインストール
+CHMPXは、あなたのOSに応じて、柔軟にインストールが可能です。あなたのOSが、Ubuntu、CentOS、Fedora、Debianなら、[packagecloud.io](https://packagecloud.io/antpickax/stable)からソースコードをビルドすることなく、簡単にインストールできます。それ以外のOSであっても、自身で[ビルド](https://chmpx.antpick.ax/buildja.html)して使うことができます。
+
 ## 構成
 CHMPXは、サーバーノードとスレーブノードの2つのタイプが存在します。  
 サーバーノードは主に、データ/サービス/機能などのリソース提供するサーバープログラムの動作するホスト上で動作させます。  

--- a/usage.md
+++ b/usage.md
@@ -52,7 +52,7 @@ The **CHMPX** publishes [packages](https://packagecloud.io/app/antpickax/stable/
 The package of the **CHMPX** is released in the form of Debian package, RPM package.  
 Since the installation method differs depending on your OS, please check the following procedure and install it.  
 
-##### Debian(Stretch) / Ubuntu(Bionic Beaver)
+##### For recent Debian-based Linux distributions users, follow the steps below:
 ```
 $ sudo apt-get update -y
 $ sudo apt-get install curl -y
@@ -64,7 +64,19 @@ To install the developer package, please install the following package.
 $ sudo apt-get install chmpx-dev
 ```
 
-##### Fedora28 / CentOS7.x(6.x)
+##### For users who use supported Fedora other than latest version, follow the steps below:
+```
+$ sudo dnf makecache
+$ sudo dnf install curl -y
+$ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh | sudo bash
+$ sudo dnf install chmpx
+```
+To install the developer package, please install the following package.
+```
+$ sudo dnf install chmpx-devel
+```
+
+##### For other recent RPM-based Linux distributions users, follow the steps below:
 ```
 $ sudo yum makecache
 $ sudo yum install curl -y

--- a/usageja.md
+++ b/usageja.md
@@ -52,7 +52,7 @@ CHMPXをビルドした後で、動作確認をしてみます。
 **CHMPX** のパッケージは、Debianパッケージ、RPMパッケージの形式で公開しています。  
 お使いのOSによりインストール方法が異なりますので、以下の手順を確認してインストールしてください。  
 
-##### Debian(Stretch) / Ubuntu(Bionic Beaver)
+##### 最近のDebianベースLinuxの利用者は、以下の手順に従ってください。
 ```
 $ sudo apt-get update -y
 $ sudo apt-get install curl -y
@@ -64,7 +64,19 @@ $ sudo apt-get install chmpx
 $ sudo apt-get install chmpx-dev
 ```
 
-##### Fedora28 / CentOS7.x(6.x)
+##### Fedoraの利用者は、以下の手順に従ってください。
+```
+$ sudo dnf makecache
+$ sudo dnf install curl -y
+$ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh | sudo bash
+$ sudo dnf install chmpx
+```
+開発者向けパッケージをインストールする場合は、以下のパッケージをインストールしてください。
+```
+$ sudo dnf install chmpx-devel
+```
+
+##### その他最近のRPMベースのLinuxの場合は、以下の手順に従ってください。
 ```
 $ sudo yum makecache
 $ sudo yum install curl -y


### PR DESCRIPTION
## Relevant Issue (if applicable)
N/A

## Details
This PR removes unsupported OS descrptions from the manuals.