### PR TITLE
Bypass a specific version of cppcheck due to poor performance

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,30 +36,36 @@ CPPCHECK_DEF=	-D SO_REUSEPORT
 CPPCHECK_IGN=
 
 # [NOTE]
-# Building chmpx on Travis CI is running in several OS.
+# Building chmpx on Github Actions(CI) is running in several OS.
 # Depending on the OS(CentOS, ubuntu, debian, fedora), different
 # cppcheck versions are installed. Certain versions of cppcheck
 # are incompatible with the chmpx template source code and are
-# very poor performance on the VM or container(Travis CI).
-# On problematic versions, timeout error on Travis CI.
-# To avoid this we skip only specific versions of cppcheck on
-# travis. Even if we skip a specific version of the cppcheck,
-# it will be tested with a combination of other versions and OS.
-# When running Travis, the TRAVIS_TAG environment variable is
-# set, and this environment variable is used for judgment.
+# very poor performance on the VM or container(CI).
+# In the problematic version, cppcheck runs very slowly. To avoid
+# this we skip only specific versions of cppcheck. Even if we
+# skip a specific version of the cppcheck, it will be tested
+# with a combination of other versions and OS.
+# When the process runs on Github Actions, the CI environment is
+# set true.
 # 
-# Currently, debian uses cppcheck 1.76, and CentOS6 uses 1.63,
-# there is a problem with this old version, skipping this.
-# If debian/etc will support 1.8x or later versions in the
+# Currently, old debian and centos use cppcheck 1.7x(or 1.6x),
+# there is a problem with these old version and skipping these.
+# If the other will support 1.8x or later versions in the
 # future, this skipped process will be unnecessary.
 #
 CPPCHECK_NGVER=	-e 1\\.7 -e 1\\.6
 
 cppcheck:
-	@echo "$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_DEF) $(CPPCHECK_IGN) $(SUBDIRS)"
-	@((((env | grep TRAVIS_TAG >/dev/null 2>&1) && echo -n TRAVISENVFOUND || echo -n NOTFOUND) && $(CPPCHECK_CMD) --version 2>/dev/null) | grep TRAVISENVFOUND | grep $(CPPCHECK_NGVER) >/dev/null 2>&1) && \
-		echo " --> Skip, because this old $(CPPCHECK_CMD) version is very poor performance on VM(CI)" || \
-		$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_DEF) $(CPPCHECK_IGN) $(SUBDIRS)
+	echo "$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_DEF) $(CPPCHECK_IGN) $(SUBDIRS)"
+	if test "X$$CI" = "Xtrue"; then \
+		if ($(CPPCHECK_CMD) --version | grep $(CPPCHECK_NGVER)) >/dev/null 2>&1; then \
+			echo " --> Skip, because this old $(CPPCHECK_CMD) version is very poor performance on VM(CI)"; \
+		else \
+			$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_DEF) $(CPPCHECK_IGN) $(SUBDIRS); \
+		fi; \
+	else \
+		$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_DEF) $(CPPCHECK_IGN) $(SUBDIRS); \
+	fi
 
 #
 # VIM modelines


### PR DESCRIPTION
#### Relevant Issue (if applicable)
n/a

#### Details
Performance drops significantly with cppcheck 1.6x and 1.7x.
(This is probably due to the parsing part of the template source code, but older versions will slow down performance.)
TravisCI dealt with it, but GithubActions didn't, so I added the corresponding code.

