### PR TITLE
Fixed docker image build for ubuntu

### DIFF
--- a/.github/workflows/imagetypevars.sh
+++ b/.github/workflows/imagetypevars.sh
@@ -74,7 +74,7 @@ elif [ "X${DOCKER_IMAGE_OSTYPE}" = "Xubuntu" ]; then
 	PKGMGR_UPDATE_OPT="update -qq -y"
 	PKGMGR_INSTALL_OPT="install -qq -y"
 	PKG_INSTALL_LIST_BUILDER="git autoconf autotools-dev gcc g++ make gdb dh-make fakeroot dpkg-dev devscripts libtool pkg-config procps libyaml-dev gnutls-dev"
-	PKG_INSTALL_LIST_BIN=""
+	PKG_INSTALL_LIST_BIN="libyaml-0-2"
 
 	BUILDER_CONFIGURE_FLAG="--with-gnutls"
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Added the libyaml library because it was missing in the Docker image of Ubuntu.