### PR TITLE
Enabled external customization of configure.ac and fixed for building

### DIFF
--- a/.github/workflows/ostypevars.sh
+++ b/.github/workflows/ostypevars.sh
@@ -146,6 +146,11 @@ elif [ "X${CI_OSTYPE}" = "Xcentos:8" -o "X${CI_OSTYPE}" = "Xcentos:centos8" ]; t
 	PKG_EXT="rpm"
 	IS_OS_CENTOS=1
 
+	#
+	# Change mirrorlist
+	#
+	sed -i -e 's|^mirrorlist|#mirrorlist|g' -e 's|^#baseurl=http://mirror|baseurl=http://vault|g' /etc/yum.repos.d/CentOS-*repo
+
 	# [NOTE]
 	# For CentOS8, installing libyaml-devel from PowerTools( PwoerTools -> powertools at 2020/12 )
 	#

--- a/.gitignore
+++ b/.gitignore
@@ -152,7 +152,10 @@ tests/test.sh.log
 tests/test.sh.trs
 
 #
-# VIM modelines
-#
-# vim:set ts=4 fenc=utf-8:
+# Local variables:
+# tab-width: 4
+# c-basic-offset: 4
+# End:
+# vim600: noexpandtab sw=4 ts=4 fdm=marker
+# vim<600: noexpandtab sw=4 ts=4
 #

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@
 
 SUBDIRS=lib src tests docs buildutils
 ACLOCAL_AMFLAGS = -I m4
-EXTRA_DIST=RELEASE_VERSION
+EXTRA_DIST=RELEASE_VERSION @CONFIGURECUSTOM@
 
 CPPCHECK_CMD=	cppcheck
 CPPCHECK_OPT=	--quiet \
@@ -68,7 +68,10 @@ cppcheck:
 	fi
 
 #
-# VIM modelines
-#
-# vim:set ts=4 fenc=utf-8:
+# Local variables:
+# tab-width: 4
+# c-basic-offset: 4
+# End:
+# vim600: noexpandtab sw=4 ts=4 fdm=marker
+# vim<600: noexpandtab sw=4 ts=4
 #

--- a/configure.ac
+++ b/configure.ac
@@ -52,11 +52,6 @@ AC_PROG_RANLIB
 AC_CHECK_LIB(dl, dlopen)
 
 #
-# Checks for header files.
-#
-AC_CHECK_HEADERS([locale.h netdb.h fcntl.h sys/socket.h sys/time.h endian.h sys/endian.h netinet/in.h])
-
-#
 # Checks for typedefs, structures, and compiler characteristics.
 #
 AC_HEADER_STDBOOL
@@ -79,20 +74,45 @@ AC_FUNC_MKTIME
 AC_FUNC_FORK
 AC_FUNC_ERROR_AT_LINE
 AC_CHECK_FUNCS([ftruncate gethostname memset regcomp setlocale strcasecmp strncasecmp strdup strrchr clock_gettime munmap select socket uname gettimeofday strstr inet_ntoa])
-AC_CHECK_HEADERS([termios.h arpa/inet.h])
+AC_CHECK_HEADERS([locale.h netdb.h fcntl.h sys/socket.h sys/time.h endian.h sys/endian.h netinet/in.h termios.h arpa/inet.h inttypes.h strings.h unistd.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_HEADER_RESOLV
 
 #
+# Load customizable variables
+#
+AC_CHECK_FILE([configure.custom],
+	[
+		configure_custom_file="configure.custom"
+		custom_git_domain="$(grep '^\s*GIT_DOMAIN\s*=' configure.custom | sed -e 's|^\s*GIT_DOMAIN\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_org="$(grep '^\s*GIT_ORG\s*=' configure.custom | sed -e 's|^\s*GIT_ORG\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_repo="$(grep '^\s*GIT_REPO\s*=' configure.custom | sed -e 's|^\s*GIT_REPO\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_endpoint="$(grep '^\s*GIT_EP_V3_REPO\s*=' configure.custom | sed -e 's|^\s*GIT_EP_V3_REPO\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_dev_email="$(grep '^\s*DEV_EMAIL\s*=' configure.custom | sed -e 's|^\s*DEV_EMAIL\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_dev_name="$(grep '^\s*DEB_NAME\s*=' configure.custom | sed -e 's|^\s*DEB_NAME\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+	],
+	[
+		configure_custom_file=""
+		custom_git_domain="github.com"
+		custom_git_org="yahoojapan"
+		custom_git_repo="chmpx"
+		custom_git_endpoint="https://api.github.com/repos/"
+		custom_dev_email="antpickax-support@mail.yahoo.co.jp"
+		custom_dev_name="CHMPX_DEVELOPER"
+	]
+)
+
+#
 # Symbols for buildutils
 #
-AC_SUBST([GIT_DOMAIN], "github.com")
-AC_SUBST([GIT_ORG], "yahoojapan")
-AC_SUBST([GIT_REPO], "chmpx")
-AC_SUBST([CURRENTREV], "`$(pwd)/buildutils/make_commit_hash.sh -o yahoojapan -r chmpx -short`")
-AC_SUBST([DEV_EMAIL], "`echo ${DEBEMAIL:-antpickax-support@mail.yahoo.co.jp}`")
-AC_SUBST([DEV_NAME], "`echo ${DEBFULLNAME:-CHMPX_DEVELOPER}`")
-
+AC_SUBST([CONFIGURECUSTOM], "${configure_custom_file}")
+AC_SUBST([GIT_DOMAIN], "${custom_git_domain}")
+AC_SUBST([GIT_ORG], "${custom_git_org}")
+AC_SUBST([GIT_REPO], "${custom_git_repo}")
+AC_SUBST([CURRENTREV], "$($(pwd)/buildutils/make_commit_hash.sh -o "${custom_git_org}" -r "${custom_git_repo}" -ep "${custom_git_endpoint}" -short)")
+AC_SUBST([DEV_EMAIL], "$(echo ${DEBEMAIL:-"${custom_dev_email}"})")
+AC_SUBST([DEV_NAME], "$(echo ${DEBFULLNAME:-"${custom_dev_name}"})")
+#
 AC_SUBST([RPMCHANGELOG], "`$(pwd)/buildutils/make_rpm_changelog.sh $(pwd)/ChangeLog`")
 AC_SUBST([SHORTDESC], "`$(pwd)/buildutils/make_description.sh $(pwd)/docs/chmpx.1 -short`")
 AC_SUBST([LONGDESC], "`$(pwd)/buildutils/make_description.sh $(pwd)/docs/chmpx.1 -long`")
@@ -242,7 +262,10 @@ AC_CONFIG_FILES([Makefile
 AC_OUTPUT
 
 #
-# VIM modelines
-#
-# vim:set ts=4 fenc=utf-8:
+# Local variables:
+# tab-width: 4
+# c-basic-offset: 4
+# End:
+# vim600: noexpandtab sw=4 ts=4 fdm=marker
+# vim<600: noexpandtab sw=4 ts=4
 #

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -108,8 +108,15 @@ libchmpx_la_LDFLAGS	= -version-info $(LIB_VERSION_INFO)
 libchmpx_la_LIBADD	= $(k2hash_LIBS) $(fullock_LIBS) $(SSL_TLS_LIBS) -lyaml -lrt -lresolv -lpthread
 
 ACLOCAL_AMFLAGS		= -I m4
-AM_CFLAGS			= $(k2hash_CFLAGS) $(fullock_CFLAGS)
-AM_CPPFLAGS			= $(k2hash_CFLAGS) $(fullock_CFLAGS)
+
+# [NOTE]
+# "-Waddress-of-packed-member" optsion was introduced by default
+# from GCC 9.
+# Knowing that packed structure is CPU architecture dependent,
+# this program ignores this warning.
+#
+AM_CFLAGS			= $(k2hash_CFLAGS) $(fullock_CFLAGS) -Wno-address-of-packed-member
+AM_CPPFLAGS			= $(k2hash_CFLAGS) $(fullock_CFLAGS) -Wno-address-of-packed-member
 
 ### version(commit hash)
 .PHONY:	chmpxversion
@@ -118,7 +125,10 @@ chmpxversion.cc:	chmpxversion
 	@../buildutils/make_commit_hash_source.sh chmpxversion.cc chmpx_commit_hash
 
 #
-# VIM modelines
-#
-# vim:set ts=4 fenc=utf-8:
+# Local variables:
+# tab-width: 4
+# c-basic-offset: 4
+# End:
+# vim600: noexpandtab sw=4 ts=4 fdm=marker
+# vim<600: noexpandtab sw=4 ts=4
 #

--- a/lib/chmcntrl.cc
+++ b/lib/chmcntrl.cc
@@ -510,6 +510,8 @@ bool ChmCntrl::EventLoop(void)
 				if(0L == ImData.GetUpServerCount()){
 					// Check any server up
 					if(pEventSock->InitialAllServerStatus()){
+						// cppcheck-suppress unmatchedSuppression
+						// cppcheck-suppress knownConditionTrueFalse
 						if(0L < ImData.GetUpServerCount()){
 							// Try to connect servers
 							//MSG_CHMPRN("Try to connect servers on RING(mode is SLAVE).");
@@ -530,6 +532,8 @@ bool ChmCntrl::EventLoop(void)
 						// [NOTE]
 						// This case is that there are no other server node up.
 						if(pEventSock->InitialAllServerStatus()){
+							// cppcheck-suppress unmatchedSuppression
+							// cppcheck-suppress knownConditionTrueFalse
 							if(1L < ImData.GetUpServerCount()){
 								// Try to connect servers
 								//MSG_CHMPRN("Try to connect servers on RING(mode is SERVER).");

--- a/lib/chmcommon.h
+++ b/lib/chmcommon.h
@@ -65,13 +65,13 @@ template<typename T> inline bool CHMEMPTYSTR(const T pstr)
 #define CHMPXSTRJOIN(first, second)			first ## second
 
 #if defined(__cplusplus)
-#define	CHM_OFFSET(baseaddr, offset, type)	(offset > 0 ? reinterpret_cast<type>(reinterpret_cast<off_t>(baseaddr) + offset) : reinterpret_cast<type>(baseaddr)) 					// convert pointer with offset
-#define	CHM_ABS(baseaddr, offset, type)		(reinterpret_cast<off_t>(offset) > 0 ? reinterpret_cast<type>(reinterpret_cast<off_t>(baseaddr) + reinterpret_cast<off_t>(offset)) : 0) // To Absolute address
-#define	CHM_REL(baseaddr, address, type)	(address > 0 ? reinterpret_cast<type>(reinterpret_cast<off_t>(address) - reinterpret_cast<off_t>(baseaddr)) : 0)						// To Relative address
+#define	CHM_OFFSET(baseaddr, offset, type)	((offset > 0) ? reinterpret_cast<type>(reinterpret_cast<off_t>(baseaddr) + offset) : reinterpret_cast<type>(baseaddr))						// convert pointer with offset
+#define	CHM_ABS(baseaddr, offset, type)		((reinterpret_cast<off_t>(offset) > 0) ? reinterpret_cast<type>(reinterpret_cast<off_t>(baseaddr) + reinterpret_cast<off_t>(offset)) : 0)	// To Absolute address
+#define	CHM_REL(baseaddr, address, type)	((reinterpret_cast<off_t>(address) > 0) ? reinterpret_cast<type>(reinterpret_cast<off_t>(address) - reinterpret_cast<off_t>(baseaddr)) : 0)	// To Relative address
 #else	// __cplusplus
-#define	CHM_OFFSET(baseaddr, offset, type)	(offset > 0 ? (type)((off_t)baseaddr + offset) : (type)baseaddr) 	// convert pointer with offset
-#define	CHM_ABS(baseaddr, offset, type)		(offset > 0 ? (type)((off_t)baseaddr + (off_t)offset) : 0) 			// To Absolute address
-#define	CHM_REL(baseaddr, address, type)	(address > 0 ? (type)((off_t)address - (off_t)baseaddr) : 0)		// To Relative address
+#define	CHM_OFFSET(baseaddr, offset, type)	((offset > 0) ? (type)((off_t)baseaddr + (off_t)offset) : (type)baseaddr)	// convert pointer with offset
+#define	CHM_ABS(baseaddr, offset, type)		(((off_t)offset > 0) ? (type)((off_t)baseaddr + (off_t)offset) : 0)			// To Absolute address
+#define	CHM_REL(baseaddr, address, type)	(((off_t)address > 0) ? (type)((off_t)address - (off_t)baseaddr) : 0)		// To Relative address
 #endif	// __cplusplus
 
 //---------------------------------------------------------

--- a/lib/chmconf.cc
+++ b/lib/chmconf.cc
@@ -352,7 +352,7 @@ bool CHMConf::Clean(void)
 		UnsetEventQueue();
 	}
 
-	while(!fullock::flck_trylock_noshared_mutex(&CHMConf::lockval));	// LOCK
+	while(!fullock::flck_trylock_noshared_mutex(&CHMConf::lockval)){}	// LOCK
 	CHM_Delete(pchmcfginfo);
 	fullock::flck_unlock_noshared_mutex(&CHMConf::lockval);				// UNLOCK
 

--- a/lib/chmeventmq.cc
+++ b/lib/chmeventmq.cc
@@ -1625,25 +1625,23 @@ bool ChmEventMq::RawReceive(mqd_t mqfd, const COMPOSEDMSGID& composed)
 	pComPkt = pTmp;
 
 	// Dispatching
-	if(pComPkt){
-		bool	is_need_ack	= (COM_C2C == pComPkt->head.type && use_mq_ack && pChmCntrl->IsChmpxType());
+	bool	is_need_ack	= (COM_C2C == pComPkt->head.type && use_mq_ack && pChmCntrl->IsChmpxType());
 
-		if(pChmCntrl && !pChmCntrl->Processing(pComPkt, ChmCntrl::EVOBJ_TYPE_EVMQ)){
-			// send failure ack
-			if(is_need_ack && !SendAck(composed, false)){
-				ERR_CHMPRN("Failed sending failure ACK to to MQ(%d).", mqfd);
-			}
-			ERR_CHMPRN("Failed processing after receiving from MQ(%d).", mqfd);
-			CHM_Free(pComPkt);
-			return false;
+	if(pChmCntrl && !pChmCntrl->Processing(pComPkt, ChmCntrl::EVOBJ_TYPE_EVMQ)){
+		// send failure ack
+		if(is_need_ack && !SendAck(composed, false)){
+			ERR_CHMPRN("Failed sending failure ACK to to MQ(%d).", mqfd);
 		}
+		ERR_CHMPRN("Failed processing after receiving from MQ(%d).", mqfd);
 		CHM_Free(pComPkt);
+		return false;
+	}
+	CHM_Free(pComPkt);
 
-		// send success ack
-		if(is_need_ack && !SendAck(composed, true)){
-			ERR_CHMPRN("Failed sending success ACK to to MQ(%d).", mqfd);
-			return false;
-		}
+	// send success ack
+	if(is_need_ack && !SendAck(composed, true)){
+		ERR_CHMPRN("Failed sending success ACK to to MQ(%d).", mqfd);
+		return false;
 	}
 	return true;
 }

--- a/lib/chmeventshm.cc
+++ b/lib/chmeventshm.cc
@@ -198,7 +198,7 @@ bool ChmEventShm::GetEventQueueFds(event_fds_t& fds)
 
 bool ChmEventShm::SetEventQueue(void)
 {
-	if(0 == chmshmfile.c_str()){
+	if(chmshmfile.empty()){
 		ERR_CHMPRN("This object does not have chmshm file path.");
 		return false;
 	}

--- a/lib/chmeventsock.cc
+++ b/lib/chmeventsock.cc
@@ -1459,7 +1459,7 @@ bool ChmEventSock::ReceiveWorkerProc(void* common_param, chmthparam_t wp_param)
 	// cppcheck-suppress unmatchedSuppression
 	// cppcheck-suppress nullPointerRedundantCheck
 	suseconds_t	waittime = pSockObj->sock_wait_time;
-	bool		is_closed;
+	bool		is_closed= false;
 	int			werr;
 	while(0 == (werr = ChmEventSock::WaitForReady(sock, WAIT_READ_FD, 0, false, waittime))){		// check rest data & return assap
 		// Processing
@@ -7587,7 +7587,7 @@ bool ChmEventSock::PxComSendStatusReq(int sock, chmpxid_t chmpxid, bool need_soc
 	return true;
 }
 
-bool ChmEventSock::PxComReceiveStatusReq(PCOMHEAD pComHead, PPXCOM_ALL pComAll, PCOMPKT* ppResComPkt)
+bool ChmEventSock::PxComReceiveStatusReq(PCOMHEAD pComHead, const PPXCOM_ALL pComAll, PCOMPKT* ppResComPkt)
 {
 	if(!pComHead || !pComAll || !ppResComPkt){
 		ERR_CHMPRN("Parameter are wrong.");
@@ -9971,7 +9971,7 @@ bool ChmEventSock::PxComSendMergeSuspendGet(int sock, chmpxid_t chmpxid)
 	return true;
 }
 
-bool ChmEventSock::PxComReceiveMergeSuspendGet(PCOMHEAD pComHead, PPXCOM_ALL pComAll, PCOMPKT* ppResComPkt)
+bool ChmEventSock::PxComReceiveMergeSuspendGet(PCOMHEAD pComHead, const PPXCOM_ALL pComAll, PCOMPKT* ppResComPkt)
 {
 	if(!pComHead || !pComAll || !ppResComPkt){
 		ERR_CHMPRN("Parameter are wrong.");
@@ -10204,7 +10204,7 @@ bool ChmEventSock::PxComReceiveServerDown(PCOMHEAD pComHead, PPXCOM_ALL pComAll,
 	return true;
 }
 
-bool ChmEventSock::PxCltReceiveJoinNotify(PCOMHEAD pComHead, PPXCLT_ALL pComAll)
+bool ChmEventSock::PxCltReceiveJoinNotify(const PCOMHEAD pComHead, const PPXCLT_ALL pComAll)
 {
 	if(!pComHead || !pComAll){
 		ERR_CHMPRN("Parameter are wrong.");
@@ -10532,7 +10532,7 @@ bool ChmEventSock::PxComSendResUpdateData(chmpxid_t chmpxid, size_t length, cons
 	return true;
 }
 
-bool ChmEventSock::PxComReceiveResUpdateData(PCOMHEAD pComHead, PPXCOM_ALL pComAll)
+bool ChmEventSock::PxComReceiveResUpdateData(const PCOMHEAD pComHead, PPXCOM_ALL pComAll)
 {
 	if(!pComHead || !pComAll){
 		ERR_CHMPRN("Parameter are wrong.");
@@ -10596,7 +10596,7 @@ bool ChmEventSock::PxComSendResultUpdateData(chmpxid_t chmpxid, reqidmapflag_t r
 	return true;
 }
 
-bool ChmEventSock::PxComReceiveResultUpdateData(PCOMHEAD pComHead, PPXCOM_ALL pComAll)
+bool ChmEventSock::PxComReceiveResultUpdateData(const PCOMHEAD pComHead, PPXCOM_ALL pComAll)
 {
 	if(!pComHead || !pComAll){
 		ERR_CHMPRN("Parameter are wrong.");
@@ -10699,7 +10699,7 @@ bool ChmEventSock::PxComSendVersionReq(int sock, chmpxid_t chmpxid, bool need_so
 // Therefore, instead of processing in the reception main loop, CHMPX_COM_VERSION_RES is
 // returned directly in this method.
 //
-bool ChmEventSock::PxComReceiveVersionReq(int sock, PCOMHEAD pComHead, PPXCOM_ALL pComAll)
+bool ChmEventSock::PxComReceiveVersionReq(int sock, PCOMHEAD pComHead, const PPXCOM_ALL pComAll)
 {
 	if(CHM_INVALID_SOCK == sock || !pComHead || !pComAll){
 		ERR_CHMPRN("Parameter are wrong.");

--- a/lib/chmeventsock.h
+++ b/lib/chmeventsock.h
@@ -263,7 +263,7 @@ class ChmEventSock : public ChmEventBase
 
 		// px2px commands
 		bool PxComSendStatusReq(int sock, chmpxid_t chmpxid, bool need_sock_close);
-		bool PxComReceiveStatusReq(PCOMHEAD pComHead, PPXCOM_ALL pComAll, PCOMPKT* ppResComPkt);
+		bool PxComReceiveStatusReq(PCOMHEAD pComHead, const PPXCOM_ALL pComAll, PCOMPKT* ppResComPkt);
 		bool PxComReceiveStatusRes(PCOMHEAD pComHead, PPXCOM_ALL pComAll, PCOMPKT* ppResComPkt, bool is_init_process = false);
 		bool PxComSendConinitReq(int sock, chmpxid_t chmpxid);
 		bool PxComReceiveConinitReq(PCOMHEAD pComHead, PPXCOM_ALL pComAll, PCOMPKT* ppResComPkt, comver_t& comver, std::string& name, chmpxid_t& from_chmpxid, short& ctlport, std::string& cuk, std::string& custom_seed, hostport_list_t& endpoints, hostport_list_t& ctlendpoints, hostport_list_t& forward_peers, hostport_list_t& reverse_peers);
@@ -289,19 +289,19 @@ class ChmEventSock : public ChmEventBase
 		bool PxComSendMergeNoSuspend(chmpxid_t chmpxid);
 		bool PxComReceiveMergeNoSuspend(PCOMHEAD pComHead, PPXCOM_ALL pComAll, PCOMPKT* ppResComPkt);
 		bool PxComSendMergeSuspendGet(int sock, chmpxid_t chmpxid);
-		bool PxComReceiveMergeSuspendGet(PCOMHEAD pComHead, PPXCOM_ALL pComAll, PCOMPKT* ppResComPkt);
+		bool PxComReceiveMergeSuspendGet(PCOMHEAD pComHead, const PPXCOM_ALL pComAll, PCOMPKT* ppResComPkt);
 		bool PxComReceiveMergeSuspendRes(PCOMHEAD pComHead, PPXCOM_ALL pComAll);
 		bool PxComSendServerDown(chmpxid_t chmpxid, chmpxid_t downchmpxid);
 		bool PxComReceiveServerDown(PCOMHEAD pComHead, PPXCOM_ALL pComAll, PCOMPKT* ppResComPkt);
 
-		bool PxCltReceiveJoinNotify(PCOMHEAD pComHead, PPXCLT_ALL pComAll);
+		bool PxCltReceiveJoinNotify(const PCOMHEAD pComHead, const PPXCLT_ALL pComAll);
 
 		bool PxComSendReqUpdateData(chmpxid_t chmpxid, const PPXCOMMON_MERGE_PARAM pmerge_param);
 		bool PxComReceiveReqUpdateData(PCOMHEAD pComHead, PPXCOM_ALL pComAll, PCOMPKT* ppResComPkt);
-		bool PxComReceiveResUpdateData(PCOMHEAD pComHead, PPXCOM_ALL pComAll);
-		bool PxComReceiveResultUpdateData(PCOMHEAD pComHead, PPXCOM_ALL pComAll);
+		bool PxComReceiveResUpdateData(const PCOMHEAD pComHead, PPXCOM_ALL pComAll);
+		bool PxComReceiveResultUpdateData(const PCOMHEAD pComHead, PPXCOM_ALL pComAll);
 		bool PxComSendVersionReq(int sock, chmpxid_t chmpxid, bool need_sock_close);											// 1.0.71 or later
-		bool PxComReceiveVersionReq(int sock, PCOMHEAD pComHead, PPXCOM_ALL pComAll);											// 1.0.71 or later
+		bool PxComReceiveVersionReq(int sock, PCOMHEAD pComHead, const PPXCOM_ALL pComAll);										// 1.0.71 or later
 		bool PxComReceiveVersionRes(PCOMHEAD pComHead, PPXCOM_ALL pComAll, PCOMPKT* ppResComPkt, comver_t& com_proto_version);	// 1.0.71 or later
 
 	public:

--- a/lib/chmimdata.cc
+++ b/lib/chmimdata.cc
@@ -969,6 +969,8 @@ off_t ChmIMData::GetLockOffsetForMQ(void) const
 		ERR_CHMPRN("There is no attached ChmShm.");
 		return 0L;
 	}
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress clarifyCondition
 	long*	rel_freemsgcnt = CHM_REL(pChmShm, &(pChmShm->info.free_msg_count), long*);
 	return reinterpret_cast<off_t>(rel_freemsgcnt);
 }

--- a/lib/chmsigcntrl.cc
+++ b/lib/chmsigcntrl.cc
@@ -89,7 +89,7 @@ ChmSigCntrl::~ChmSigCntrl()
 {
 }
 
-bool ChmSigCntrl::Initialize(int* psignums, int count)
+bool ChmSigCntrl::Initialize(const int* psignums, int count)
 {
 	ChmSigCntrl::GetHelper().Lock();
 

--- a/lib/chmsigcntrl.h
+++ b/lib/chmsigcntrl.h
@@ -47,7 +47,7 @@ class ChmSigCntrl
 		ChmSigCntrl(void);
 		virtual ~ChmSigCntrl();
 
-		bool Initialize(int* psignums, int count);
+		bool Initialize(const int* psignums, int count);
 		bool GetSignalMask(sigset_t& sigset);
 		bool SetSignalProcMask(void);
 		bool SetHandler(int signum, sighandler_t handler) { return SetHandlerEx(signum, handler, false); }

--- a/lib/chmssnss.cc
+++ b/lib/chmssnss.cc
@@ -1046,6 +1046,8 @@ bool ChmSecureSock::SetBlockingMode(PRFileDesc* SSSession, bool is_blocking)
 	return true;
 }
 
+// cppcheck-suppress unmatchedSuppression
+// cppcheck-suppress constParameter
 bool ChmSecureSock::CheckResultSSL(int sock, ChmSSSession sslsession, long action_result, int type, bool& is_retry, bool& is_close, int retrycnt, suseconds_t waittime)
 {
 	if(CHM_INVALID_SOCK == sock || !sslsession || !IS_SAFE_CHKRESULTSSL_TYPE(type)){

--- a/lib/chmstructure.tcc
+++ b/lib/chmstructure.tcc
@@ -1993,6 +1993,8 @@ class chmpxlist_lap : public structure_lap<T>
 		chmpxlist_lap(st_ptr_type ptr = NULL, st_ptr_type* absmapptr = NULL, PCHMPX* pchmpxarrbase = NULL, PCHMPX* pchmpxarrpend = NULL, long* psockfreecnt = NULL, PCHMSOCKLIST* psockfrees = NULL, const void* shmbase = NULL, bool is_abs = true);
 
 		PCHMPX GetAbsChmpxPtr(void) const { return (basic_type::pAbsPtr ? &basic_type::pAbsPtr->chmpx : NULL); }
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress clarifyCondition
 		PCHMPX GetRelChmpxPtr(void) const { return (basic_type::pAbsPtr ? CHM_REL(basic_type::pShmBase, &basic_type::pAbsPtr->chmpx, PCHMPX) : NULL); }
 
 		void Reset(st_ptr_type ptr, st_ptr_type* absmapptr, PCHMPX* pchmpxarrbase, PCHMPX* pchmpxarrpend, long* psockfreecnt, PCHMSOCKLIST* psockfrees, const void* shmbase, bool is_abs = true);
@@ -3691,6 +3693,8 @@ class mqmsgheadlist_lap : public structure_lap<T>
 		mqmsgheadlist_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, bool is_abs = true);
 
 		PMQMSGHEAD GetAbsMqMsgHeadPtr(void) const { return (basic_type::pAbsPtr ? &basic_type::pAbsPtr->msghead : NULL); }
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress clarifyCondition
 		PMQMSGHEAD GetRelMqMsgHeadPtr(void) const { return (basic_type::pAbsPtr ? CHM_REL(basic_type::pShmBase, &basic_type::pAbsPtr->msghead, PMQMSGHEAD) : NULL); }
 
 		virtual bool Initialize(void);
@@ -4131,6 +4135,8 @@ PMQMSGHEAD mqmsgheadlist_lap<T>::Find(msgid_t msgid, bool is_abs, bool is_to_fir
 	for(st_ptr_type cur = basic_type::pAbsPtr; cur; cur = CHM_ABS(basic_type::pShmBase, cur->next, st_ptr_type)){
 		mqmsgheadlap	tmpmqmsghead(&cur->msghead, basic_type::pShmBase);
 		if(msgid == tmpmqmsghead.GetMsgId()){
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress clarifyCondition
 			return (is_abs ? &cur->msghead : CHM_REL(basic_type::pShmBase, &cur->msghead, PMQMSGHEAD));
 		}
 	}
@@ -7842,7 +7848,11 @@ class chminfo_lap : public structure_lap<T>
 		bool GetMsgidListByUniqPid(msgidlist_t& list, bool is_clear_list = false);				// Get msgid list for all uniq PID(from activated list)
 
 		pid_t GetChmpxSvrPid(void) const { return (basic_type::pAbsPtr ? basic_type::pAbsPtr->pid : CHM_INVALID_PID); }
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress clarifyCondition
 		pid_t* GetChmpxSvrPidAddr(bool is_abs) { return (!basic_type::pAbsPtr ? NULL : is_abs ? &(basic_type::pAbsPtr->pid) : CHM_REL(basic_type::pShmBase, &(basic_type::pAbsPtr->pid), pid_t*)); }
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress clarifyCondition
 		void* GetClientPidListOffset(void) { return (!basic_type::pAbsPtr ? NULL : CHM_REL(basic_type::pShmBase, &(basic_type::pAbsPtr->client_pids), void*)); }
 
 		bool GetSelfChmpxSvr(PCHMPXSVR chmpxsvr) const;

--- a/tests/chmpxbench.cc
+++ b/tests/chmpxbench.cc
@@ -876,7 +876,7 @@ static int RunChild(string cntlfile)
 			continue;
 		}
 	}
-	K2H_Delete(pthparam);
+	delete [] pthparam;
 
 	// exit
 	return EXIT_SUCCESS;


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
- Enabled to customize variables in configure.ac  
If the configure.custom file exists, it will be loaded.  
(currently unused but added to increase availability)
- Fixed an error output by cppcheck 2.7(etc)
- Fixed CentOS 8 build failing.  
It was caused by changing the mirror, so I fixed it.
- Ignore address-of-packed-member warning by GCC 9 
