### PR TITLE
Fixed packaging process and files for debian/ubuntu

### DIFF
--- a/buildutils/control.in
+++ b/buildutils/control.in
@@ -2,7 +2,7 @@ Source: @PACKAGE_NAME@
 Section: net
 Priority: optional
 Maintainer: @DEV_NAME@ <@DEV_EMAIL@>
-Build-Depends: @DEBHELPER_DEP@, dh-systemd (>= 1.5), k2hash-dev (>= 1.0.74), libfullock-dev (>= 1.0.36), libyaml-dev
+Build-Depends: @DEBHELPER_DEP@, k2hash-dev (>= 1.0.74), libfullock-dev (>= 1.0.36), libyaml-dev
 Standards-Version: 3.9.8
 Homepage: https://@GIT_DOMAIN@/@GIT_ORG@/@GIT_REPO@
 Vcs-Git: git://@GIT_DOMAIN@/@GIT_ORG@/@GIT_REPO@.git


### PR DESCRIPTION
### Relevant Issue (if applicable)


### Details
Since the `dh-systemd` package is no longer needed on ubuntu22.04 / debian11, the related files have been modified.
Also modified `make_variables.sh`.

