### PR TITLE
Fixed errors reported by cppcheck 2.9

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,7 +31,8 @@ CPPCHECK_OPT=	--quiet \
 				-j 4 \
 				--std=c++03 \
 				--xml-version=2 \
-				--enable=warning,style,information,missingInclude
+				--enable=warning,style,information,missingInclude \
+				--cppcheck-build-dir=/tmp/cppcheck
 CPPCHECK_DEF=	-D SO_REUSEPORT
 CPPCHECK_IGN=
 
@@ -53,18 +54,19 @@ CPPCHECK_IGN=
 # If the other will support 1.8x or later versions in the
 # future, this skipped process will be unnecessary.
 #
-CPPCHECK_NGVER=	-e 1\\.7 -e 1\\.6
+CPPCHECK_NGVER=	-e \^1\\.7 -e \^1\\.6
 
 cppcheck:
 	echo "$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_DEF) $(CPPCHECK_IGN) $(SUBDIRS)"
-	if test "X$$CI" = "Xtrue"; then \
-		if ($(CPPCHECK_CMD) --version | grep $(CPPCHECK_NGVER)) >/dev/null 2>&1; then \
-			echo " --> Skip, because this old $(CPPCHECK_CMD) version is very poor performance on VM(CI)"; \
-		else \
-			$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_DEF) $(CPPCHECK_IGN) $(SUBDIRS); \
-		fi; \
+	if ($(CPPCHECK_CMD) --version | sed -e 's|Cppcheck[[:space:]]*||gi' | grep -q $(CPPCHECK_NGVER)); then \
+		echo " --> Skip, because this old $(CPPCHECK_CMD) version is very poor performance on VM(CI)"; \
 	else \
+		if [ -d /tmp/cppcheck ]; then \
+			rm -rf /tmp/cppcheck; \
+		fi; \
+		mkdir /tmp/cppcheck; \
 		$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_DEF) $(CPPCHECK_IGN) $(SUBDIRS); \
+		rm -rf /tmp/cppcheck; \
 	fi
 
 #

--- a/lib/chmconf.cc
+++ b/lib/chmconf.cc
@@ -504,17 +504,17 @@ bool CHMConf::Receive(int fd)
 	// get type
 	bool	is_check_file	= false;
 	bool	is_reload		= false;
-	uint	type			= CheckNotifyEvent();
-	if(type & IN_CLOSE_WRITE){
+	uint	chktype			= CheckNotifyEvent();
+	if(chktype & IN_CLOSE_WRITE){
 		is_reload = true;
 	}
-	if(type & IN_MODIFY){
+	if(chktype & IN_MODIFY){
 		is_reload = true;
 	}
-	if(type & IN_DELETE_SELF){
+	if(chktype & IN_DELETE_SELF){
 		is_check_file = true;
 	}
-	if(type & IN_MOVE_SELF){
+	if(chktype & IN_MOVE_SELF){
 		is_check_file = true;
 	}
 

--- a/lib/chmconf.h
+++ b/lib/chmconf.h
@@ -584,7 +584,7 @@ class CHMConf : public ChmEventBase
 		PCHMCFGINFO			pchmcfginfo;
 
 	protected:
-		CHMConf(int eventqfd = CHM_INVALID_HANDLE, ChmCntrl* pcntrl = NULL, const char* file = NULL, short ctlport = CHM_INVALID_PORT, const char* cuk = NULL, const char* pJson = NULL);
+		explicit CHMConf(int eventqfd = CHM_INVALID_HANDLE, ChmCntrl* pcntrl = NULL, const char* file = NULL, short ctlport = CHM_INVALID_PORT, const char* cuk = NULL, const char* pJson = NULL);
 
 		virtual bool LoadConfiguration(CHMCFGINFO& chmcfginfo) const = 0;
 
@@ -653,7 +653,7 @@ class CHMIniConf : public CHMConf
 	friend class CHMConf;
 
 	protected:
-		CHMIniConf(int eventqfd = CHM_INVALID_HANDLE, ChmCntrl* pcntrl = NULL, const char* file = NULL, short ctlport = CHM_INVALID_PORT, const char* cuk = NULL);
+		explicit CHMIniConf(int eventqfd = CHM_INVALID_HANDLE, ChmCntrl* pcntrl = NULL, const char* file = NULL, short ctlport = CHM_INVALID_PORT, const char* cuk = NULL);
 
 		virtual bool LoadConfiguration(CHMCFGINFO& chmcfginfo) const;
 		bool LoadConfigurationRaw(CFGRAW& chmcfgraw) const;
@@ -671,7 +671,7 @@ class CHMYamlBaseConf : public CHMConf
 	friend class CHMConf;
 
 	protected:
-		CHMYamlBaseConf(int eventqfd = CHM_INVALID_HANDLE, ChmCntrl* pcntrl = NULL, const char* file = NULL, short ctlport = CHM_INVALID_PORT, const char* cuk = NULL, const char* pJson = NULL);
+		explicit CHMYamlBaseConf(int eventqfd = CHM_INVALID_HANDLE, ChmCntrl* pcntrl = NULL, const char* file = NULL, short ctlport = CHM_INVALID_PORT, const char* cuk = NULL, const char* pJson = NULL);
 
 		virtual bool LoadConfiguration(CHMCFGINFO& chmcfginfo) const;
 
@@ -687,7 +687,7 @@ class CHMJsonConf : public CHMYamlBaseConf
 	friend class CHMConf;
 
 	protected:
-		CHMJsonConf(int eventqfd = CHM_INVALID_HANDLE, ChmCntrl* pcntrl = NULL, const char* file = NULL, short ctlport = CHM_INVALID_PORT, const char* cuk = NULL);
+		explicit CHMJsonConf(int eventqfd = CHM_INVALID_HANDLE, ChmCntrl* pcntrl = NULL, const char* file = NULL, short ctlport = CHM_INVALID_PORT, const char* cuk = NULL);
 
 	public:
 		virtual ~CHMJsonConf();
@@ -701,7 +701,7 @@ class CHMJsonStringConf : public CHMYamlBaseConf
 	friend class CHMConf;
 
 	protected:
-		CHMJsonStringConf(int eventqfd = CHM_INVALID_HANDLE, ChmCntrl* pcntrl = NULL, const char* pJson = NULL, short ctlport = CHM_INVALID_PORT, const char* cuk = NULL);
+		explicit CHMJsonStringConf(int eventqfd = CHM_INVALID_HANDLE, ChmCntrl* pcntrl = NULL, const char* pJson = NULL, short ctlport = CHM_INVALID_PORT, const char* cuk = NULL);
 
 	public:
 		virtual ~CHMJsonStringConf();
@@ -715,7 +715,7 @@ class CHMYamlConf : public CHMYamlBaseConf
 	friend class CHMConf;
 
 	protected:
-		CHMYamlConf(int eventqfd = CHM_INVALID_HANDLE, ChmCntrl* pcntrl = NULL, const char* file = NULL, short ctlport = CHM_INVALID_PORT, const char* cuk = NULL);
+		explicit CHMYamlConf(int eventqfd = CHM_INVALID_HANDLE, ChmCntrl* pcntrl = NULL, const char* file = NULL, short ctlport = CHM_INVALID_PORT, const char* cuk = NULL);
 
 	public:
 		virtual ~CHMYamlConf();

--- a/lib/chmeventbase.h
+++ b/lib/chmeventbase.h
@@ -47,7 +47,7 @@ class ChmEventBase
 		ChmCntrl*	pChmCntrl;
 
 	public:
-		ChmEventBase(int eventqfd = CHM_INVALID_HANDLE, ChmCntrl* pcntrl = NULL);
+		explicit ChmEventBase(int eventqfd = CHM_INVALID_HANDLE, ChmCntrl* pcntrl = NULL);
 		virtual ~ChmEventBase();
 
 		bool IsEmpty(void) const { return (!pChmCntrl || CHM_INVALID_HANDLE == eqfd); }

--- a/lib/chmeventmq.cc
+++ b/lib/chmeventmq.cc
@@ -153,6 +153,8 @@ bool ChmEventMq::InitializeMaxMqSystemSize(long maxmsg)
 		size_t	length = 0L;
 		if(NULL == (pbuff = reinterpret_cast<char*>(chm_read(fd, &length)))){
 			ERR_CHMPRN("Could not read file %s", PROCFILE_FOR_MQ);
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress unreadVariable
 			CHM_CLOSE(fd);
 			return false;
 		}
@@ -209,6 +211,8 @@ bool ChmEventMq::MergeWorkerFunc(void* common_param, chmthparam_t wp_param)
 		}
 		// copy param
 		CHM_MERGE_GETPARAM	getparam;
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress unreadVariable
 		getparam.starthash			= 0;									// must be start position 0
 		getparam.startts.tv_nsec	= pUpdateDataParam->startts.tv_nsec;
 		getparam.startts.tv_sec		= pUpdateDataParam->startts.tv_sec;

--- a/lib/chmeventmq.h
+++ b/lib/chmeventmq.h
@@ -184,7 +184,7 @@ class ChmEventMq : public ChmEventBase
 	public:
 		static bool InitializeMaxMqSystemSize(long maxmsg);
 
-		ChmEventMq(int eventqfd = CHM_INVALID_HANDLE, ChmCntrl* pcntrl = NULL, chm_merge_get_cb mgetfp = NULL, chm_merge_set_cb msetfp = NULL, chm_merge_lastts_cb mlastfp = NULL);
+		explicit ChmEventMq(int eventqfd = CHM_INVALID_HANDLE, ChmCntrl* pcntrl = NULL, chm_merge_get_cb mgetfp = NULL, chm_merge_set_cb msetfp = NULL, chm_merge_lastts_cb mlastfp = NULL);
 		virtual ~ChmEventMq();
 
 		virtual bool Clean(void);

--- a/lib/chmeventshm.h
+++ b/lib/chmeventshm.h
@@ -54,7 +54,7 @@ class ChmEventShm : public ChmEventBase
 	public:
 		static bool CheckProcessRunning(void* common_param, chmthparam_t wp_param);
 
-		ChmEventShm(int eventqfd = CHM_INVALID_HANDLE, ChmCntrl* pcntrl = NULL, const char* file = NULL);
+		explicit ChmEventShm(int eventqfd = CHM_INVALID_HANDLE, ChmCntrl* pcntrl = NULL, const char* file = NULL);
 		virtual ~ChmEventShm();
 
 		virtual bool Clean(void);

--- a/lib/chmeventsock.cc
+++ b/lib/chmeventsock.cc
@@ -910,6 +910,8 @@ bool ChmEventSock::RawSendCtlPort(const char* hostname, short ctlport, const uns
 	if(!ChmEventSock::RawSend(ctlsock, NULL, pbydata, length, is_closed, false, retrycnt, waittime)){
 		ERR_CHMPRN("Could not send to %s:%d(sock:%d).", hostname, ctlport, ctlsock);
 		if(!is_closed){
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress unreadVariable
 			CHM_CLOSESOCK(ctlsock);
 		}
 		return false;
@@ -923,6 +925,8 @@ bool ChmEventSock::RawSendCtlPort(const char* hostname, short ctlport, const uns
 	if(!ChmEventSock::RawReceiveAny(ctlsock, is_closed, reinterpret_cast<unsigned char*>(szReceive), &RecLength, false, retrycnt * 10, waittime)){	// wait 10 times by normal
 		ERR_CHMPRN("Failed to receive data from ctlport ctlsock(%d), ctlsock is %s.", ctlsock, is_closed ? "closed" : "not closed");
 		if(!is_closed){
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress unreadVariable
 			CHM_CLOSESOCK(ctlsock);
 		}
 		return false;
@@ -2119,6 +2123,8 @@ bool ChmEventSock::SetEventQueue(void)
 		eqevent.events	= EPOLLIN | EPOLLET | EPOLLRDHUP;			// EPOLLRDHUP is set
 		if(-1 == epoll_ctl(eqfd, EPOLL_CTL_ADD, sock, &eqevent)){
 			ERR_CHMPRN("Failed to add sock(port %d: sock %d) into epoll event(%d), errno=%d", port, sock, eqfd, errno);
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress unreadVariable
 			CHM_CLOSESOCK(sock);
 			return false;
 		}
@@ -2130,6 +2136,8 @@ bool ChmEventSock::SetEventQueue(void)
 		if(CHM_INVALID_SOCK != sock){
 			epoll_ctl(eqfd, EPOLL_CTL_DEL, sock, NULL);
 		}
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress unreadVariable
 		CHM_CLOSESOCK(sock);
 		return false;
 	}
@@ -2143,7 +2151,11 @@ bool ChmEventSock::SetEventQueue(void)
 		if(CHM_INVALID_SOCK != sock){
 			epoll_ctl(eqfd, EPOLL_CTL_DEL, sock, NULL);
 		}
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress unreadVariable
 		CHM_CLOSESOCK(sock);
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress unreadVariable
 		CHM_CLOSESOCK(ctlsock);
 		return false;
 	}
@@ -3567,6 +3579,7 @@ bool ChmEventSock::CloseSSL(int sock, bool with_sock)
 		// cppcheck-suppress unmatchedSuppression
 		// cppcheck-suppress uselessAssignmentPtrArg
 		// cppcheck-suppress uselessAssignmentArg
+		// cppcheck-suppress unreadVariable
 		CHM_CLOSESOCK(sock);
 	}
 	return true;
@@ -4262,6 +4275,8 @@ bool ChmEventSock::Accept(int sock)
 	string	strhostname;
 	if(!ChmNetDb::CvtAddrInfoToIpAddress(&from, fromlen, stripaddress)){
 		ERR_CHMPRN("Failed to convert addrinfo(new sock=%d) to ipaddress.", newsock);
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress unreadVariable
 		CHM_CLOSESOCK(newsock);
 		return false;
 	}
@@ -5969,6 +5984,8 @@ bool ChmEventSock::ContinuousAutoMerge(void)
 			startup_servicein = false;
 
 			// re-get status
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress unreadVariable
 			status = pImData->GetSelfStatus();
 		}else{
 			// Not [SERVICE OUT] [UP] [NOACT] [NOTHING] status

--- a/lib/chmeventsock.h
+++ b/lib/chmeventsock.h
@@ -309,7 +309,7 @@ class ChmEventSock : public ChmEventBase
 		static void DenySelfSignedCert(void);
 		static int WaitForReady(int sock, int type, int retrycnt, bool is_check_so_error = false, suseconds_t waittime = CHMEVENTSOCK_TIMEOUT_DEFAULT);
 
-		ChmEventSock(int eventqfd = CHM_INVALID_HANDLE, ChmCntrl* pcntrl = NULL, bool is_ssl = false);
+		explicit ChmEventSock(int eventqfd = CHM_INVALID_HANDLE, ChmCntrl* pcntrl = NULL, bool is_ssl = false);
 		virtual ~ChmEventSock();
 
 		bool InitialAllServerStatus(void);

--- a/lib/chmimdata.cc
+++ b/lib/chmimdata.cc
@@ -690,6 +690,8 @@ bool ChmIMData::InitializeShmEx(const CHMCFGINFO& chmcfg, const CHMNODE_CFGINFO*
 	// truncate with filling zero
 	if(!truncate_filling_zero(fd, total_shmsize, ChmIMData::SYSPAGE_SIZE)){
 		ERR_CHMPRN("Could not truncate file(%s) with filling zero.", shmpath.c_str());
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress unreadVariable
 		CHM_CLOSE(fd);
 		return false;
 	}
@@ -698,6 +700,8 @@ bool ChmIMData::InitializeShmEx(const CHMCFGINFO& chmcfg, const CHMNODE_CFGINFO*
 	void*	shmbase;
 	if(MAP_FAILED == (shmbase = mmap(NULL, total_shmsize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0))){
 		ERR_CHMPRN("Could not mmap file(%s), errno = %d", shmpath.c_str(), errno);
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress unreadVariable
 		CHM_CLOSE(fd);
 		return false;
 	}
@@ -739,6 +743,8 @@ bool ChmIMData::InitializeShmEx(const CHMCFGINFO& chmcfg, const CHMNODE_CFGINFO*
 				chmpxlistlap	tmpchmpxlist(&chmpxlist[cnt], NULL, NULL, NULL, NULL, NULL, shmbase);		// absmapptr, chmpx*s are NULL, these can allow only here(calling only Initialize()).
 				if(!tmpchmpxlist.Initialize(prev, next)){
 					ERR_CHMPRN("Failed to initialize No.%ld CHMPXLIST.", cnt);
+					// cppcheck-suppress unmatchedSuppression
+					// cppcheck-suppress unreadVariable
 					CHM_MUMMAP(fd, shmbase, total_shmsize);
 					return false;
 				}
@@ -759,6 +765,8 @@ bool ChmIMData::InitializeShmEx(const CHMCFGINFO& chmcfg, const CHMNODE_CFGINFO*
 				mqmsgheadlistlap	tmpmqmsgheadlist(&mqmsglist[cnt], shmbase);
 				if(!tmpmqmsgheadlist.Initialize(prev, next)){
 					ERR_CHMPRN("Failed to initialize No.%ld MQMSGHEADLIST.", cnt);
+					// cppcheck-suppress unmatchedSuppression
+					// cppcheck-suppress unreadVariable
 					CHM_MUMMAP(fd, shmbase, total_shmsize);
 					return false;
 				}
@@ -774,6 +782,8 @@ bool ChmIMData::InitializeShmEx(const CHMCFGINFO& chmcfg, const CHMNODE_CFGINFO*
 				cltproclistlap	tmpcltproclist(&cltproclist[cnt], shmbase);
 				if(!tmpcltproclist.Initialize(prev, next)){
 					ERR_CHMPRN("Failed to initialize No.%ld PCLTPROCLIST.", cnt);
+					// cppcheck-suppress unmatchedSuppression
+					// cppcheck-suppress unreadVariable
 					CHM_MUMMAP(fd, shmbase, total_shmsize);
 					return false;
 				}
@@ -785,6 +795,8 @@ bool ChmIMData::InitializeShmEx(const CHMCFGINFO& chmcfg, const CHMNODE_CFGINFO*
 				chmlograwlap	tmplograw(&lograw[cnt], shmbase);
 				if(!tmplograw.Initialize()){
 					ERR_CHMPRN("Failed to initialize No.%ld CHMLOGRAW.", cnt);
+					// cppcheck-suppress unmatchedSuppression
+					// cppcheck-suppress unreadVariable
 					CHM_MUMMAP(fd, shmbase, total_shmsize);
 					return false;
 				}
@@ -800,6 +812,8 @@ bool ChmIMData::InitializeShmEx(const CHMCFGINFO& chmcfg, const CHMNODE_CFGINFO*
 				chmsocklistlap	tmpchmsocklist(&chmsocklist[cnt], shmbase);
 				if(!tmpchmsocklist.Initialize(prev, next)){
 					ERR_CHMPRN("Failed to initialize No.%ld PCHMSOCKLIST.", cnt);
+					// cppcheck-suppress unmatchedSuppression
+					// cppcheck-suppress unreadVariable
 					CHM_MUMMAP(fd, shmbase, total_shmsize);
 					return false;
 				}
@@ -817,6 +831,8 @@ bool ChmIMData::InitializeShmEx(const CHMCFGINFO& chmcfg, const CHMNODE_CFGINFO*
 		chmloglap	tmpchmlog(&pChmBase->chmpxlog, shmbase);
 		if(!tmpchmlog.Initialize(rel_lograwarea, chmcfg.max_histlog_count)){
 			ERR_CHMPRN("Failed to initialize CHMLOG.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress unreadVariable
 			CHM_MUMMAP(fd, shmbase, total_shmsize);
 			return false;
 		}
@@ -825,6 +841,8 @@ bool ChmIMData::InitializeShmEx(const CHMCFGINFO& chmcfg, const CHMNODE_CFGINFO*
 		chminfolap	tmpchminfo(&pChmBase->info, shmbase);
 		if(!tmpchminfo.Initialize(&chmcfg, rel_chmpxmsgarea, pself, pnormalizedname, rel_chmpxarea, rel_chmpxpidarea, rel_chmsockarea, rel_pchmpxarr_base, rel_pchmpxarr_pend)){
 			ERR_CHMPRN("Failed to initialize CHMINFO.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress unreadVariable
 			CHM_MUMMAP(fd, shmbase, total_shmsize);
 			return false;
 		}
@@ -895,6 +913,8 @@ bool ChmIMData::AttachShm(void)
 	void*	shmbase;
 	if(MAP_FAILED == (shmbase = mmap(NULL, total_shmsize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0))){
 		ERR_CHMPRN("Could not mmap file(%s), errno = %d", shmpath.c_str(), errno);
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress unreadVariable
 		CHM_CLOSE(fd);
 		return false;
 	}
@@ -903,6 +923,8 @@ bool ChmIMData::AttachShm(void)
 	PCHMSHM	pTmpChmShm = reinterpret_cast<PCHMSHM>(shmbase);
 	if(!ChmIMData::IsSafeCHMINFO(&(pTmpChmShm->info))){
 		ERR_CHMPRN("Unsafe CHMINFO file(%s), probably this is created by old CHMPX version", shmpath.c_str());
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress unreadVariable
 		CHM_MUMMAP(fd, shmbase, total_shmsize);
 		return false;
 	}

--- a/lib/chmkvp.h
+++ b/lib/chmkvp.h
@@ -41,7 +41,7 @@ class ChmBinData
 		bool			is_allocate;
 
 	public:
-		ChmBinData(unsigned char* bydata = NULL, size_t bylength = 0L, bool is_duplicate = false);
+		explicit ChmBinData(unsigned char* bydata = NULL, size_t bylength = 0L, bool is_duplicate = false);
 		ChmBinData(PCHMBIN pchmbin, bool is_duplicate);
 		virtual ~ChmBinData();
 
@@ -77,7 +77,7 @@ class ChmKVPair
 		ChmBinData	Value;
 
 	public:
-		ChmKVPair(unsigned char* bykey = NULL, size_t keylen = 0L, unsigned char* byval = NULL, size_t vallen = 0L, bool is_duplicate = false);
+		explicit ChmKVPair(unsigned char* bykey = NULL, size_t keylen = 0L, unsigned char* byval = NULL, size_t vallen = 0L, bool is_duplicate = false);
 		ChmKVPair(ChmBinData* pKey, ChmBinData* pValue, bool is_duplicate = false);
 		ChmKVPair(PCHMKVP pkvp, bool is_duplicate);
 		virtual ~ChmKVPair();

--- a/lib/chmlockmap.tcc
+++ b/lib/chmlockmap.tcc
@@ -56,7 +56,7 @@ class chm_lock_map
 		chm_lock_map(void) : lockval(FLCK_NOSHARED_MUTEX_VAL_UNLOCKED), pbasefunc(NULL), pbaseparam(NULL) {}
 
 	public:
-		chm_lock_map(const val_type& initval, chm_lock_map_erase_cb pfunc = NULL, void* pparam = NULL) : lockval(FLCK_NOSHARED_MUTEX_VAL_UNLOCKED), pbasefunc(pfunc), pbaseparam(pparam), emptyval(initval) {}
+		explicit chm_lock_map(const val_type& initval, chm_lock_map_erase_cb pfunc = NULL, void* pparam = NULL) : lockval(FLCK_NOSHARED_MUTEX_VAL_UNLOCKED), pbasefunc(pfunc), pbaseparam(pparam), emptyval(initval) {}
 		virtual ~chm_lock_map(void) { clear(); }
 
 		inline size_t count(void);

--- a/lib/chmnetdb.cc
+++ b/lib/chmnetdb.cc
@@ -962,7 +962,7 @@ bool ChmNetDb::InitializeLocalHostnames()
 				// add cache
 				if(!is_same_nodename || !fulllocalname.empty()){
 					memset(&ipaddr, 0, sizeof(ipaddr));
-					if(0 == (result = getnameinfo(tmpaddrinfo->ai_addr, tmpaddrinfo->ai_addrlen, ipaddr, sizeof(ipaddr), NULL, 0, NI_NUMERICHOST))){
+					if(0 == getnameinfo(tmpaddrinfo->ai_addr, tmpaddrinfo->ai_addrlen, ipaddr, sizeof(ipaddr), NULL, 0, NI_NUMERICHOST)){
 						HostnammeAddCache(string(hostname), string(ipaddr), true);
 
 						if(is_same_nodename && !fulllocalname.empty()){
@@ -1328,7 +1328,7 @@ bool ChmNetDb::GetHostAddressInfo(const char* target, CHMNDBCACHE& data)
 
 			// add cache
 			bool	is_hostname = false;
-			if(0 != (result = getnameinfo(tmpaddrinfo->ai_addr, tmpaddrinfo->ai_addrlen, hostname, sizeof(hostname), NULL, 0, NI_NAMEREQD | NI_NUMERICSERV))){
+			if(0 != getnameinfo(tmpaddrinfo->ai_addr, tmpaddrinfo->ai_addrlen, hostname, sizeof(hostname), NULL, 0, NI_NAMEREQD | NI_NUMERICSERV)){
 				is_hostname = true;
 				IpAddressAddCache(string(ipaddr), string(hostname));
 			}

--- a/lib/chmopts.h
+++ b/lib/chmopts.h
@@ -35,7 +35,7 @@ class ChmOpts
 		std::string	sepchars;
 
 	public:
-		ChmOpts(int argc = 0, char** argv = NULL, const char* strsepchars = NULL);
+		explicit ChmOpts(int argc = 0, char** argv = NULL, const char* strsepchars = NULL);
 		virtual ~ChmOpts();
 
 		bool Initialize(int argc, char** argv);

--- a/lib/chmssgnutls.cc
+++ b/lib/chmssgnutls.cc
@@ -60,7 +60,7 @@ typedef struct chm_gnutls_ss_context{
 	string	strSlaveCert;
 	string	strSlavePKey;
 
-	chm_gnutls_ss_context(const char* pServerCert = NULL, const char* pServerPKey = NULL, const char* pSlaveCert = NULL, const char* pSlavePKey = NULL) : 
+	explicit chm_gnutls_ss_context(const char* pServerCert = NULL, const char* pServerPKey = NULL, const char* pSlaveCert = NULL, const char* pSlavePKey = NULL) : 
 		strServerCert(CHMEMPTYSTR(pServerCert) ? "" : pServerCert), strServerPKey(CHMEMPTYSTR(pServerPKey) ? "" : pServerPKey), strSlaveCert(CHMEMPTYSTR(pSlaveCert) ? "" : pSlaveCert), strSlavePKey(CHMEMPTYSTR(pSlavePKey) ? "" : pSlavePKey)
 	{
 	}
@@ -113,7 +113,7 @@ typedef struct chm_gnutls_session{
 	gnutls_session_t					session;
 	gnutls_priority_t					priority_cache;
 
-	chm_gnutls_session(bool is_svr = false, ChmSSCtx ctx = NULL, gnutls_certificate_credentials_t cert = NULL, gnutls_session_t ses = NULL, gnutls_priority_t pricache = NULL) :
+	explicit chm_gnutls_session(bool is_svr = false, ChmSSCtx ctx = NULL, gnutls_certificate_credentials_t cert = NULL, gnutls_session_t ses = NULL, gnutls_priority_t pricache = NULL) :
 		is_server(is_svr), SSCtx(NULL), cert_cred(cert), session(ses), priority_cache(pricache)
 	{
 		// cppcheck-suppress unmatchedSuppression

--- a/lib/chmssgnutls.h
+++ b/lib/chmssgnutls.h
@@ -72,7 +72,7 @@ class ChmSecureSock
 		static int Read(ChmSSSession sslsession, void* pbuf, int length);
 		static int Write(ChmSSSession sslsession, const void* pbuf, int length);
 
-		ChmSecureSock(const char* CApath = NULL, const char* CAfile = NULL, bool is_verify_peer = false);
+		explicit ChmSecureSock(const char* CApath = NULL, const char* CAfile = NULL, bool is_verify_peer = false);
 		virtual ~ChmSecureSock();
 
 		bool Clean(void);

--- a/lib/chmssnss.cc
+++ b/lib/chmssnss.cc
@@ -101,7 +101,7 @@ typedef struct chm_nss_ss_context{
 	CERTCertificate*	CERT_OBJ_slave;
 	SECKEYPrivateKey*	PKEY_OBJ_slave;
 
-	chm_nss_ss_context(const char* pServer = NULL, CERTCertificate* cert_server = NULL, SECKEYPrivateKey* pkey_server = NULL, const char* pSlave = NULL, CERTCertificate* cert_slave = NULL, SECKEYPrivateKey* pkey_slave = NULL) :
+	explicit chm_nss_ss_context(const char* pServer = NULL, CERTCertificate* cert_server = NULL, SECKEYPrivateKey* pkey_server = NULL, const char* pSlave = NULL, CERTCertificate* cert_slave = NULL, SECKEYPrivateKey* pkey_slave = NULL) :
 		strServerKey(CHMEMPTYSTR(pServer) ? "" : pServer), CERT_OBJ_server(cert_server), PKEY_OBJ_server(pkey_server), strSlaveKey(CHMEMPTYSTR(pSlave) ? "" : pSlave), CERT_OBJ_slave(cert_slave), PKEY_OBJ_slave(pkey_slave)
 	{
 	}
@@ -241,7 +241,7 @@ typedef struct chm_nss_session{
 	PRFileDesc*		SSSession;
 	chmpk11list_t	pk11objs;
 
-	chm_nss_session(ChmSSCtx ctx = NULL, PRFileDesc* session = NULL, chmpk11list_t* ppk11objs = NULL) : SSCtx(NULL), SSSession(session)
+	explicit chm_nss_session(ChmSSCtx ctx = NULL, PRFileDesc* session = NULL, chmpk11list_t* ppk11objs = NULL) : SSCtx(NULL), SSSession(session)
 	{
 		// cppcheck-suppress unmatchedSuppression
 		// cppcheck-suppress noOperatorEq

--- a/lib/chmssnss.h
+++ b/lib/chmssnss.h
@@ -105,7 +105,7 @@ class ChmSecureSock
 		static int Read(ChmSSSession sslsession, void* pbuf, int length);
 		static int Write(ChmSSSession sslsession, const void* pbuf, int length);
 
-		ChmSecureSock(const char* CApath = NULL, const char* CAfile = NULL, bool is_verify_peer = false);
+		explicit ChmSecureSock(const char* CApath = NULL, const char* CAfile = NULL, bool is_verify_peer = false);
 		virtual ~ChmSecureSock();
 
 		bool Clean(void);

--- a/lib/chmssopenssl.h
+++ b/lib/chmssopenssl.h
@@ -81,7 +81,7 @@ class ChmSecureSock
 		static int Read(ChmSSSession sslsession, void* pbuf, int length);
 		static int Write(ChmSSSession sslsession, const void* pbuf, int length);
 
-		ChmSecureSock(const char* CApath = NULL, const char* CAfile = NULL, bool is_verify_peer = false);
+		explicit ChmSecureSock(const char* CApath = NULL, const char* CAfile = NULL, bool is_verify_peer = false);
 		virtual ~ChmSecureSock();
 
 		bool Clean(void);

--- a/lib/chmstructure.tcc
+++ b/lib/chmstructure.tcc
@@ -464,7 +464,7 @@ class structure_lap
 		const void*		pShmBase;
 
 	public:
-		structure_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, bool is_abs = true);
+		explicit structure_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, bool is_abs = true);
 		virtual ~structure_lap();
 
 		st_ptr_type GetAbsPtr(void) const { return pAbsPtr; }
@@ -533,7 +533,7 @@ class chmsocklist_lap : public structure_lap<T>
 		typedef structure_lap<T>	basic_type;
 
 	public:
-		chmsocklist_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, bool is_abs = true);
+		explicit chmsocklist_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, bool is_abs = true);
 
 		virtual bool Initialize(void);
 		bool Initialize(st_ptr_type prev, st_ptr_type next, bool is_abs = true);
@@ -925,7 +925,7 @@ class chmpx_lap : public structure_lap<T>
 		bool Initialize(CHMPXID_SEED_TYPE type, const char* hostname, const char* group, CHMPXMODE mode, short port, short ctlport, const char* cuk, const char* custom_seed, const PCHMPXHP_RAWPAIR pendpoints, const PCHMPXHP_RAWPAIR pctlendpoints, const PCHMPXHP_RAWPAIR pforward_peers, const PCHMPXHP_RAWPAIR preverse_peers, const CHMPXSSL& ssl);
 
 	public:
-		chmpx_lap(st_ptr_type ptr = NULL, st_ptr_type* pchmpxarrbase = NULL, st_ptr_type* pchmpxarrpend = NULL, long* psockfreecnt = NULL, PCHMSOCKLIST* pabssockfrees = NULL, const void* shmbase = NULL, bool is_abs = true);
+		explicit chmpx_lap(st_ptr_type ptr = NULL, st_ptr_type* pchmpxarrbase = NULL, st_ptr_type* pchmpxarrpend = NULL, long* psockfreecnt = NULL, PCHMSOCKLIST* pabssockfrees = NULL, const void* shmbase = NULL, bool is_abs = true);
 
 		void Reset(st_ptr_type ptr, st_ptr_type* pchmpxarrbase, st_ptr_type* pchmpxarrpend, long* psockfreecnt, PCHMSOCKLIST* pabssockfrees, const void* shmbase, bool is_abs = true);
 		virtual bool Initialize(void);
@@ -1990,7 +1990,7 @@ class chmpxlist_lap : public structure_lap<T>
 		st_ptr_type SearchChmpxid(chmpxid_t chmpxid);
 
 	public:
-		chmpxlist_lap(st_ptr_type ptr = NULL, st_ptr_type* absmapptr = NULL, PCHMPX* pchmpxarrbase = NULL, PCHMPX* pchmpxarrpend = NULL, long* psockfreecnt = NULL, PCHMSOCKLIST* psockfrees = NULL, const void* shmbase = NULL, bool is_abs = true);
+		explicit chmpxlist_lap(st_ptr_type ptr = NULL, st_ptr_type* absmapptr = NULL, PCHMPX* pchmpxarrbase = NULL, PCHMPX* pchmpxarrpend = NULL, long* psockfreecnt = NULL, PCHMSOCKLIST* psockfrees = NULL, const void* shmbase = NULL, bool is_abs = true);
 
 		PCHMPX GetAbsChmpxPtr(void) const { return (basic_type::pAbsPtr ? &basic_type::pAbsPtr->chmpx : NULL); }
 		// cppcheck-suppress unmatchedSuppression
@@ -3273,7 +3273,7 @@ class chmstat_lap : public structure_lap<T>
 		typedef structure_lap<T>	basic_type;
 
 	public:
-		chmstat_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, bool is_abs = true);
+		explicit chmstat_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, bool is_abs = true);
 
 		virtual bool Initialize(void);
 		virtual bool Dump(std::stringstream& sstream, const char* spacer) const;
@@ -3431,7 +3431,7 @@ class mqmsghead_lap : public structure_lap<T>
 		typedef structure_lap<T>	basic_type;
 
 	public:
-		mqmsghead_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, bool is_abs = true);
+		explicit mqmsghead_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, bool is_abs = true);
 
 		virtual bool Initialize(void);
 		virtual bool Dump(std::stringstream& sstream, const char* spacer) const;
@@ -3627,7 +3627,7 @@ class mqmsgheadarr_lap : public structure_lap<T>
 		long						chmpxmsg_count;
 
 	public:
-		mqmsgheadarr_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, long max_msg_count = 0L, bool is_abs = true);
+		explicit mqmsgheadarr_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, long max_msg_count = 0L, bool is_abs = true);
 
 		bool FillMsgId(msgid_t base_msgid);
 		long Count(void) const { return chmpxmsg_count; }
@@ -3690,7 +3690,7 @@ class mqmsgheadlist_lap : public structure_lap<T>
 		typedef structure_lap<T>	basic_type;
 
 	public:
-		mqmsgheadlist_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, bool is_abs = true);
+		explicit mqmsgheadlist_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, bool is_abs = true);
 
 		PMQMSGHEAD GetAbsMqMsgHeadPtr(void) const { return (basic_type::pAbsPtr ? &basic_type::pAbsPtr->msghead : NULL); }
 		// cppcheck-suppress unmatchedSuppression
@@ -4253,7 +4253,7 @@ class chmlograw_lap : public structure_lap<T>
 		typedef structure_lap<T>	basic_type;
 
 	public:
-		chmlograw_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, bool is_abs = true);
+		explicit chmlograw_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, bool is_abs = true);
 
 		virtual bool Initialize(void);
 		virtual bool Dump(std::stringstream& sstream, const char* spacer) const;
@@ -4387,7 +4387,7 @@ class chmlog_lap : public structure_lap<T>
 		typedef structure_lap<T>	basic_type;
 
 	public:
-		chmlog_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, bool is_abs = true);
+		explicit chmlog_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, bool is_abs = true);
 
 		virtual bool Initialize(void);
 		virtual bool Dump(std::stringstream& sstream, const char* spacer) const;
@@ -4660,7 +4660,7 @@ class cltproclist_lap : public structure_lap<T>
 		typedef structure_lap<T>	basic_type;
 
 	public:
-		cltproclist_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, bool is_abs = true);
+		explicit cltproclist_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, bool is_abs = true);
 
 		virtual bool Initialize(void);
 		bool Initialize(st_ptr_type prev, st_ptr_type next, bool is_abs = true);
@@ -5072,7 +5072,7 @@ class chmpxman_lap : public structure_lap<T>
 		bool RawCheckContainsChmpxSvrs(const char* hostname, const short* pctlport, const char* pcuk, std::string* pnormalizedname, PCHMPXSSL pssl) const;
 
 	public:
-		chmpxman_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, bool is_abs = true);
+		explicit chmpxman_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, bool is_abs = true);
 
 		virtual bool Initialize(void);
 		virtual bool Dump(std::stringstream& sstream, const char* spacer) const;
@@ -7822,7 +7822,7 @@ class chminfo_lap : public structure_lap<T>
 		bool SetMergingClinetPid(pid_t pid);
 
 	public:
-		chminfo_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, bool is_abs = true);
+		explicit chminfo_lap(st_ptr_type ptr = NULL, const void* shmbase = NULL, bool is_abs = true);
 
 		virtual bool Initialize(void);
 		virtual bool Dump(std::stringstream& sstream, const char* spacer) const;

--- a/tests/chmpxbench.cc
+++ b/tests/chmpxbench.cc
@@ -157,7 +157,7 @@ static bool SetStringBytes(string& str, size_t totallength, char ch)
 			str += ch;
 		}
 	}else{	// (str.length() + 1) > totallength
-		str = str.substr(0, (totallength - 1));
+		str.resize(totallength - 1);
 	}
 	return true;
 }
@@ -691,7 +691,6 @@ static void* RunSlaveModeThread(void* param)
 		pthread_exit(NULL);
 	}
 	string	strbase = to_hexstring(gettid()) + "-";
-	string	strmessage;
 
 	// wait for start
 	// cppcheck-suppress unmatchedSuppression
@@ -715,6 +714,7 @@ static void* RunSlaveModeThread(void* param)
 	// Loop: Do read/write to k2hash
 	//---------------------------
 	for(int cnt = 0; 0 == pThParam->pexeccntl->opt.LoopCnt || cnt < pThParam->pexeccntl->opt.LoopCnt; ++cnt){
+		string			strmessage;
 		PCOMPKT			pComPkt	= NULL;
 		unsigned char*	pbody	= NULL;
 		size_t			length	= 0L;

--- a/tests/chmpxlinetool.cc
+++ b/tests/chmpxlinetool.cc
@@ -2983,7 +2983,7 @@ static string CutEmptyLine(const string& strBase)
 {
 	string	strResult = strBase;
 	if(!strResult.empty() && '\n' == strResult[strResult.length() - 1]){
-		strResult = strResult.substr(0, strResult.length() - 1);
+		strResult.resize(strResult.length() - 1);
 	}
 	return strResult;
 }
@@ -3233,6 +3233,8 @@ static bool AddNodesFromDumpResult(nodectrllist_t& nodes, string& strDump)
 		strParsed = strParsed.substr(pos + strlen(DUMP_KEY_CR));
 
 		// Parse slave chmpxs
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress unreadVariable
 		strParsed = ParseChmpxListFromDumpResult(nodes, strParsed, false, is_error);
 		if(is_error){
 			ERR("Could not parse server chmpx.");
@@ -3718,6 +3720,8 @@ static bool CreateStatusDetails(NODESTATUSDETAIL& detail, chmpxid_t chmpxid, con
 		strParsed		= strParsed.substr(pos + strlen(DUMP_KEY_CR));
 		if(strChmpxCount != "0"){
 			// Parse slave chmpxs
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress unreadVariable
 			strParsed = ParseUnitDatasFromDumpResult(detail.slaves, exceptchmpxid, false, strParsed);
 		}
 	}
@@ -4719,7 +4723,7 @@ static string CvtAllStatusResult(const string& strResult, bool& is_error)
 			if(string::npos != (pos2 = strLastUpdate.find("("))){
 				strLastUpdate		= strLastUpdate.substr(pos2 + 1);
 				if(string::npos != (pos2 = strLastUpdate.find(")"))){
-					strLastUpdate	= strLastUpdate.substr(0, pos2);
+					strLastUpdate.resize(pos2);
 				}else{
 					// why?, but continue...
 				}
@@ -5145,22 +5149,22 @@ static bool parse_host_parameter(const string& params, string& host, short& ctrl
 	string::size_type	chpos;
 	if(string::npos != (chpos = host.find(":"))){
 		string	strport	= host.substr(chpos + 1);
-		host			= host.substr(0, chpos);
+		host.resize(chpos);
 
 		if(string::npos == (chpos = strport.find(":"))){
 			ctrlport	= static_cast<short>(atoi(strport.c_str()));
 		}else{
 			cuk			= strport.substr(chpos + 1);
-			strport		= strport.substr(0, chpos);
+			strport.resize(chpos);
 			ctrlport	= static_cast<short>(atoi(strport.c_str()));
 
 			if(string::npos != (chpos = cuk.find(":"))){
 				custom_seed	= cuk.substr(chpos + 1);
-				cuk			= cuk.substr(0, chpos);
+				cuk.resize(chpos);
 
 				if(string::npos != (chpos = custom_seed.find(":"))){
 					ctlendpoints= custom_seed.substr(chpos + 1);
-					custom_seed	= custom_seed.substr(0, chpos);
+					custom_seed.resize(chpos);
 				}
 			}
 		}


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Fixed errors reported by cppcheck 2.9.
Also changed the cppcheck version dependent bypass conditions.

