### PR TITLE
Fixed .gitignore to exclude APKBUILD.templ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ Makefile
 Makefile.in
 Dockerfile
 buildutils/Dockerfile.templ
+buildutils/APKBUILD.templ
 
 #
 # archive files and backups


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
Fixed leaking `buildutils/APKBUILD.templ` in `.gitignore`.