### PR TITLE
Improved IPv6 support and support for launch host domains

### DIFF
--- a/buildutils/APKBUILD.templ.in
+++ b/buildutils/APKBUILD.templ.in
@@ -53,6 +53,7 @@ arch="x86_64"
 license="MIT"
 
 depends="
+	procps
 	k2hash
 "
 depends_dev="
@@ -66,7 +67,6 @@ makedepends="
 	groff
 	util-linux-misc
 	musl-locales
-	procps
 	yaml-dev
 	@ALP_DEPS_TLS_DEV_PKG@
 "

--- a/lib/chmconf.cc
+++ b/lib/chmconf.cc
@@ -2302,10 +2302,13 @@ bool CHMIniConf::LoadConfiguration(CHMCFGINFO& chmcfginfo) const
 		for(strlst_t::const_iterator svrnodeiter = expand_svrnodes.begin(); svrnodeiter != expand_svrnodes.end(); ++svrnodeiter){
 			strlst_t	nodehost_list;
 			nodehost_list.clear();
+			nodehost_list.push_back(*svrnodeiter);
+
 			if(!ChmNetDb::Get()->GetAllHostList(svrnodeiter->c_str(), nodehost_list, true)){
 				// if not found hostname/IP addresses for server node, add the original hostname
 				nodehost_list.push_back(*svrnodeiter);
 			}
+
 			// set first hostname
 			svrnode.name = nodehost_list.front();
 			chmcfginfo.servers.push_back(svrnode);
@@ -2316,7 +2319,7 @@ bool CHMIniConf::LoadConfiguration(CHMCFGINFO& chmcfginfo) const
 				for(strlst_t::const_iterator nodehostiter = nodehost_list.begin(); nodehost_list.end() != nodehostiter; ++nodehostiter){
 					for(strlst_t::const_iterator liter = localhost_list.begin(); localhost_list.end() != liter; ++liter){
 						if(0 == strcasecmp(nodehostiter->c_str(), liter->c_str())){
-							MSG_CHMPRN("Found self host name(%s) in server node list.", nodehostiter->c_str());
+							MSG_CHMPRN("Found self host name(%s) in server node list.", nodehostiter->c_str());				// FOUND
 							ccvals.server_mode_by_comp	= true;
 							is_break_loop				= true;
 							break;
@@ -2325,6 +2328,12 @@ bool CHMIniConf::LoadConfiguration(CHMCFGINFO& chmcfginfo) const
 					if(is_break_loop){
 						break;
 					}
+				}
+				// Set self server node name in configuration to localhostname cache.
+				if(!ChmNetDb::Get()->ReplaceFullLocalName(svrnode.name.c_str())){
+					ERR_CHMPRN("Failed to replace full local hostname(%s) in cache, but continue...", svrnode.name.c_str());
+				}else{
+					MSG_CHMPRN("Replaced full local hostname(%s) in cache.", svrnode.name.c_str());
 				}
 			}
 		}

--- a/lib/chmnetdb.h
+++ b/lib/chmnetdb.h
@@ -53,6 +53,7 @@ class ChmNetDb
 		static const time_t	ALIVE_TIME	= 60;	// default 60s
 		static int			lockval;			// like mutex
 		static const size_t	PORT_NMATCH	= 5;	// maximum 3 matches + 2(reserve)
+		static bool			inet6;				// inet6 is allowed
 
 		chmndbmap_t			cachemap;
 		time_t				timeout;			// 0 means no timeout
@@ -91,7 +92,7 @@ class ChmNetDb
 		static bool GetLocalHostname(std::string& hostname);
 		static bool GetLocalHostnameList(strlst_t& hostnames);
 		static bool GetLocalHostList(strlst_t& hostinfo, bool remove_localhost = false);
-		static bool GetAnyAddrInfo(short port, struct addrinfo** ppaddrinfo, bool is_inetv6);
+		static bool GetAnyAddrInfo(short port, struct addrinfo** ppaddrinfo, bool is_inet6);
 		static bool CvtAddrInfoToIpAddress(struct sockaddr_storage* info, socklen_t infolen, std::string& stripaddress);
 		static bool CvtSockToLocalPort(int sock, short& port);
 		static bool CvtSockToPeerPort(int sock, short& port);
@@ -109,6 +110,7 @@ class ChmNetDb
 		bool GetHostnameList(const char* target, strlst_t& hostnames, bool is_cvt_localhost);
 		bool GetIpAddressString(const char* target, std::string& ipaddress, bool is_cvt_localhost);
 		bool GetIpAddressStringList(const char* target, strlst_t& ipaddrs, bool is_cvt_localhost);
+		bool ReplaceFullLocalName(const char* localneme);
 		bool GetAllHostList(const char* target, strlst_t& expandlist, bool is_cvt_localhost);
 };
 

--- a/lib/chmstructure.tcc
+++ b/lib/chmstructure.tcc
@@ -470,7 +470,7 @@ class structure_lap
 		st_ptr_type GetAbsPtr(void) const { return pAbsPtr; }
 		st_ptr_type GetRelPtr(void) const { return CHM_REL(pShmBase, pAbsPtr, st_ptr_type); }
 
-		virtual void Reset(st_ptr_type ptr, const void* shmbase, bool is_abs = true);
+		void Reset(st_ptr_type ptr, const void* shmbase, bool is_abs = true);
 		virtual bool Initialize(void);
 		virtual bool Dump(std::stringstream& sstream, const char* spacer) const;
 		virtual bool Clear(void);

--- a/tests/chmpxlinetool.cc
+++ b/tests/chmpxlinetool.cc
@@ -6904,6 +6904,14 @@ int main(int argc, char** argv)
 	// Initialize map
 	HostnameMap::Initialize();
 
+	// Initialize ChmNetDb
+	//
+	// [NOTE]
+	// We can initialize the ChmNetDb singleton by calling ChmNetDb::Get().
+	// Initialization allows to configure INET6(Ipv6) in advance.
+	//
+	ChmNetDb::Get();
+
 	//----------------------
 	// initialize nodes information
 	//----------------------


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
For hosts (containers) that do not have an IPv6 network interface, the environment is detected and INET6 is not used for name resolution.
This was causing timeouts in ALPINE and other programs.
We also addressed the case where the hostname domain differs from the domain name registered in DNS.
Finally, the dependencies of the ALPINE package have been fixed.
