### PR TITLE
Avoided latest cppcheck error which maybe a false positive

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -265,8 +265,8 @@ AM_CONDITIONAL([IS_OPENSSL3],			[test "$is_openssl3" = yes])
 #
 # Version list for Libraries
 #
-AC_SUBST([LIB_MINVER_LIBK2HASH], "1.0.98")
-AC_SUBST([LIB_MINVER_LIBFULLOCK], "1.0.62")
+AC_SUBST([LIB_MINVER_LIBK2HASH], "1.0.99")
+AC_SUBST([LIB_MINVER_LIBFULLOCK], "1.0.63")
 
 #
 # Check for k2hash + libfullock
@@ -281,8 +281,8 @@ AC_ARG_ENABLE(check-depend-libs,
 	esac]
 )
 AS_IF([test ${check_depend_libs} = 1], [AC_MSG_RESULT(yes)], [AC_MSG_RESULT(no)])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([k2hash], [libk2hash >= 1.0.98], [], [AC_MSG_ERROR(not found k2hash package)])])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([fullock], [libfullock >= 1.0.62], [], [AC_MSG_ERROR(not found libfullock package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([k2hash], [libk2hash >= 1.0.99], [], [AC_MSG_ERROR(not found k2hash package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([fullock], [libfullock >= 1.0.63], [], [AC_MSG_ERROR(not found libfullock package)])])
 
 #
 # CFLAGS/CXXFLAGS

--- a/lib/chmcntrl.cc
+++ b/lib/chmcntrl.cc
@@ -644,6 +644,8 @@ bool ChmCntrl::Processing(PCOMPKT pComPkt, EVOBJTYPE call_ev_type)
 	}else if(COM_C2PX == pComPkt->head.type || COM_PX2C == pComPkt->head.type){
 		// Input from MQ, so processing do on MQ
 		//
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress constVariablePointer
 		const PPXCLT_ALL pCltAll = CVT_CLT_ALL_PTR_PXCOMPKT(pComPkt);
 		if(IS_PXCLT_TYPE(pCltAll, CHMPX_CLT_JOIN_NOTIFY)){
 			// CHMPX_CLT_JOIN_NOTIFY type is processing by ChmEventSock.

--- a/lib/chmimdata.cc
+++ b/lib/chmimdata.cc
@@ -383,6 +383,8 @@ void ChmIMData::FreeDupSelfChmpxInfo(PCHMPX ptr)
 	}
 }
 
+// cppcheck-suppress unmatchedSuppression
+// cppcheck-suppress constParameterPointer
 bool ChmIMData::IsSafeCHMINFO(const PCHMINFO pchminfo)
 {
 	if(!pchminfo){


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
The latest cppcheck(v2.11 or 2.14 or later) is falsely detecting a `constParameterPointer` and `constVariablePointer` error when specifying `const` using the typedef name of a structure pointer.
Therefore, avoided this by adding an inline suppress.
