### PR TITLE
Updated files for release 1.0.112

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+chmpx (1.0.112) unstable; urgency=low
+
+  * Common build_helper.sh script was updated for fedora:44 - #153
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Wed, 15 Apr 2026 18:16:48 +0900
+
 chmpx (1.0.111) unstable; urgency=low
 
   * Changed support OS and Fixed some code - #151


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
#### Changes from 1.0.111 to 1.0.112
- Common build_helper.sh script was updated for fedora:44 - #153